### PR TITLE
Week 1 production hardening: ErrorBoundary, env validation, observability (#338, #339, #340)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,9 +57,16 @@ VITE_ENTRA_TENANT_ID=50fcb752-2a4e-4efd-bdc2-e18a5042c5a8
 VITE_ENTRA_AUTHORITY=https://login.microsoftonline.com/50fcb752-2a4e-4efd-bdc2-e18a5042c5a8
 VITE_ENTRA_REDIRECT_URI=http://localhost:5173/auth/callback
 
-# Real-time Service
+# --- Server-side (App Service / Hono backend) ---
+# These are NOT VITE_-prefixed: they are read by the backend (server/ and api/),
+# never exposed to the browser. Required in production (DEV_MODE=false).
+#
+# Azure Table Storage (FATAL if missing in production — data persistence):
+AZURE_STORAGE_CONNECTION_STRING=
+#
+# Real-time Service (Web PubSub — required for live location broadcasting):
 AZURE_WEBPUBSUB_CONNECTION_STRING=
-AZURE_WEBPUBSUB_HUB_NAME=
+AZURE_WEBPUBSUB_HUB_NAME=santa_tracking
 
 # =============================================================================
 # OG IMAGE GENERATION (Optional - enhances social media previews)

--- a/api/src/health.ts
+++ b/api/src/health.ts
@@ -1,0 +1,61 @@
+/**
+ * Health & readiness endpoints (#340) — Azure Functions parity with the Hono
+ * server's /api/health and /api/ready.
+ *
+ * - health: liveness, cheap, no external calls.
+ * - ready:  readiness, probes Azure Table Storage reachability.
+ */
+
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+import { TableServiceClient } from '@azure/data-tables';
+import { STORAGE_CONNECTION_STRING } from './utils/storage';
+
+const startedAt = Date.now();
+const VERSION = process.env.APP_VERSION ?? process.env.WEBSITE_DEPLOYMENT_ID ?? 'dev';
+
+export async function health(): Promise<HttpResponseInit> {
+  return {
+    status: 200,
+    jsonBody: {
+      status: 'ok',
+      version: VERSION,
+      uptimeSeconds: Math.round((Date.now() - startedAt) / 1000),
+      timestamp: new Date().toISOString(),
+    },
+  };
+}
+
+async function pingStorage(): Promise<{ configured: boolean; ok: boolean; error?: string }> {
+  if (!STORAGE_CONNECTION_STRING) {
+    return { configured: false, ok: false, error: 'connection string not configured' };
+  }
+  try {
+    const serviceClient = TableServiceClient.fromConnectionString(STORAGE_CONNECTION_STRING);
+    await serviceClient.listTables().byPage({ maxPageSize: 1 }).next();
+    return { configured: true, ok: true };
+  } catch (error) {
+    return { configured: true, ok: false, error: (error as Error).message };
+  }
+}
+
+export async function ready(
+  _request: HttpRequest,
+  _context: InvocationContext,
+): Promise<HttpResponseInit> {
+  const storage = await pingStorage();
+  const webPubSub = { configured: !!process.env.AZURE_WEBPUBSUB_CONNECTION_STRING };
+  const isReady = storage.ok;
+
+  return {
+    status: isReady ? 200 : 503,
+    jsonBody: {
+      status: isReady ? 'ready' : 'not_ready',
+      checks: { storage, webPubSub },
+      version: VERSION,
+      timestamp: new Date().toISOString(),
+    },
+  };
+}
+
+app.http('health', { methods: ['GET'], authLevel: 'anonymous', handler: health });
+app.http('ready', { methods: ['GET'], authLevel: 'anonymous', handler: ready });

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,6 +1,7 @@
 // Central entrypoint that imports all function modules so the Azure Functions
 // TypeScript build emits a single `dist/index.js` the Functions host can load.
 
+import './health';
 import './brigades';
 import './rfs-stations';
 import './routes';

--- a/docs/PRODUCTION_DEPLOYMENT_CHECKLIST.md
+++ b/docs/PRODUCTION_DEPLOYMENT_CHECKLIST.md
@@ -438,16 +438,28 @@ Required for production (`VITE_DEV_MODE=false` / `DEV_MODE=false`):
 
 ### Health Checks
 
-- [ ] `/api/health` endpoint (if created) returning 200
-- [ ] Uptime monitoring configured (Azure Monitor, external)
+Endpoints (implemented in both `server/` and `api/`):
+
+| Endpoint | Purpose | Healthy response |
+| --- | --- | --- |
+| `GET /api/health` | **Liveness** — cheap, no external calls. Point availability tests here. | `200 { status: "ok", version, uptimeSeconds }` |
+| `GET /api/ready` | **Readiness** — probes Table Storage + reports Web PubSub config. | `200 { status: "ready" }`, or `503 { status: "not_ready" }` when storage is unreachable |
+
+- [ ] Azure Monitor availability test targets `GET /api/health` (not `/ready`, to avoid storage cost on every probe)
+- [ ] App Service health-check path set to `/api/health`
+- [ ] Alert when `/api/ready` returns 503 (storage down)
 - [ ] SSL certificate expiration monitoring
 - [ ] Domain expiration monitoring (if custom domain)
 
 ### Error Tracking
 
-- [ ] Error logs monitored (Azure Static Web Apps logs)
-- [ ] API function errors logged
-- [ ] Client-side errors captured (if error tracking service used)
+Client errors are forwarded to `POST /api/client-errors` (production only, via
+`installClientErrorReporter`) and logged server-side as `[client-error] {...}`
+single-line JSON, captured by App Service / Application Insights.
+
+- [ ] Log query / alert on `[client-error]` and `[config] FATAL` log lines
+- [ ] API function errors logged and reviewed
+- [ ] Client-side error volume dashboard (App Insights)
 - [ ] Weekly error review scheduled
 
 ---

--- a/docs/PRODUCTION_DEPLOYMENT_CHECKLIST.md
+++ b/docs/PRODUCTION_DEPLOYMENT_CHECKLIST.md
@@ -40,6 +40,27 @@ This comprehensive checklist ensures all critical steps are completed before and
 - [ ] Deployment guide reviewed and updated
 - [ ] Changelog updated with release notes
 
+### Environment Configuration Validation
+
+Startup validators fail fast on bad config: the client (`src/config/env.ts`) shows
+a fatal-config screen instead of a blank page; the server
+(`server/src/utils/configValidation.ts`) refuses to start without storage.
+
+Required for production (`VITE_DEV_MODE=false` / `DEV_MODE=false`):
+
+| Variable | Side | Severity if missing |
+| --- | --- | --- |
+| `VITE_MAPBOX_TOKEN` (public `pk.` token) | client (build) | **fatal** — maps/geocoding/directions broken |
+| `VITE_ENTRA_CLIENT_ID` / `VITE_ENTRA_TENANT_ID` / `VITE_ENTRA_AUTHORITY` | client (build) | **fatal** — auth cannot initialise |
+| `VITE_ENTRA_REDIRECT_URI` | client (build) | warning — falls back to `origin/auth/callback` |
+| `AZURE_STORAGE_CONNECTION_STRING` | server (App Service) | **fatal** — no data persistence |
+| `AZURE_WEBPUBSUB_CONNECTION_STRING` | server (App Service) | warning — no live broadcasting |
+
+- [ ] All variables above set for the target environment (see `.env.example`)
+- [ ] `VITE_ENTRA_AUTHORITY` is tenant-specific (no `/common`, no `/oauth2/.../authorize`)
+- [ ] Mapbox token is a public `pk.` token with URL restrictions (never an `sk.` secret)
+- [ ] Verified the app boots cleanly (no fatal-config screen, no `[config] FATAL` logs)
+
 ### Version Control
 
 - [ ] All changes committed to feature branch

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -11,12 +11,15 @@ import { verificationRouter } from './routes/verification.js';
 import { adminVerificationRouter } from './routes/admin-verification.js';
 import { claimRouter } from './routes/claim.js';
 import { analyticsRouter } from './routes/analytics.js';
+import { healthRouter } from './routes/health.js';
+import { telemetryRouter } from './routes/telemetry.js';
 
 export function createApp() {
   const app = new Hono();
 
-  // Health check
-  app.get('/api/health', (c) => c.json({ status: 'ok', timestamp: new Date().toISOString() }));
+  // Health, readiness, and client telemetry ingestion.
+  app.route('/api', healthRouter);
+  app.route('/api', telemetryRouter);
 
   // API routes
   app.route('/api/brigades', brigadesRouter);

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,6 +1,10 @@
 import { serve } from '@hono/node-server';
 import { serveStatic } from '@hono/node-server/serve-static';
 import { createApp } from './app.js';
+import { validateServerEnv } from './utils/configValidation.js';
+
+// Fail fast on invalid configuration before accepting any traffic.
+validateServerEnv();
 
 // Path to the built React SPA, relative to process.cwd() (the deployment root).
 // Start the server from the repository root so that './dist' resolves to the

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -1,0 +1,48 @@
+/**
+ * Health & readiness endpoints for launch-night monitoring (#340).
+ *
+ * - GET /api/health — liveness. Cheap, no external calls. Point Azure Monitor
+ *   availability tests here.
+ * - GET /api/ready  — readiness. Probes dependencies (storage reachability,
+ *   Web PubSub configuration). Returns 503 when a critical dependency is down.
+ */
+
+import { Hono } from 'hono';
+import { pingStorage } from '../utils/storage.js';
+
+const startedAt = Date.now();
+
+// App version, surfaced for correlating deploys with incidents.
+const VERSION = process.env.APP_VERSION ?? process.env.WEBSITE_DEPLOYMENT_ID ?? 'dev';
+
+export const healthRouter = new Hono();
+
+// Liveness — must stay cheap (no network calls).
+healthRouter.get('/health', (c) =>
+  c.json({
+    status: 'ok',
+    version: VERSION,
+    uptimeSeconds: Math.round((Date.now() - startedAt) / 1000),
+    timestamp: new Date().toISOString(),
+  }),
+);
+
+// Readiness — checks the dependencies needed to serve real traffic.
+healthRouter.get('/ready', async (c) => {
+  const storage = await pingStorage();
+  const webPubSub = { configured: !!process.env.AZURE_WEBPUBSUB_CONNECTION_STRING };
+
+  // Storage is critical; Web PubSub being unconfigured only disables live
+  // broadcasting, so it does not flip readiness to false on its own.
+  const ready = storage.ok;
+
+  return c.json(
+    {
+      status: ready ? 'ready' : 'not_ready',
+      checks: { storage, webPubSub },
+      version: VERSION,
+      timestamp: new Date().toISOString(),
+    },
+    ready ? 200 : 503,
+  );
+});

--- a/server/src/routes/telemetry.ts
+++ b/server/src/routes/telemetry.ts
@@ -1,0 +1,50 @@
+/**
+ * Client telemetry ingestion (#340).
+ *
+ * Receives client-side error reports (from the ErrorBoundary / global handlers)
+ * and writes them to the server log, where App Service / Application Insights
+ * captures them. Intentionally minimal and best-effort: validates shape, caps
+ * payload size, and never fails the caller in a way worth retrying.
+ */
+
+import { Hono } from 'hono';
+
+export const telemetryRouter = new Hono();
+
+interface ClientErrorPayload {
+  message?: unknown;
+  source?: unknown;
+  stack?: unknown;
+  url?: unknown;
+  userAgent?: unknown;
+}
+
+const MAX_FIELD_LENGTH = 4000;
+
+function clip(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  return value.slice(0, MAX_FIELD_LENGTH);
+}
+
+telemetryRouter.post('/client-errors', async (c) => {
+  let body: ClientErrorPayload;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ status: 'ignored', reason: 'invalid json' }, 400);
+  }
+
+  const record = {
+    message: clip(body.message) ?? '(no message)',
+    source: clip(body.source) ?? 'unknown',
+    stack: clip(body.stack),
+    url: clip(body.url),
+    userAgent: clip(body.userAgent) ?? c.req.header('user-agent'),
+    receivedAt: new Date().toISOString(),
+  };
+
+  // Structured single-line log so it is greppable in App Service / App Insights.
+  console.error(`[client-error] ${JSON.stringify(record)}`);
+
+  return c.json({ status: 'received' }, 202);
+});

--- a/server/src/utils/configValidation.ts
+++ b/server/src/utils/configValidation.ts
@@ -1,0 +1,84 @@
+/**
+ * Server-side environment validation.
+ *
+ * Asserts the backend has the configuration it needs before accepting traffic.
+ * Called once at startup (see server/src/main.ts).
+ *
+ * - Development mode (DEV_MODE=true): logs warnings only, never exits.
+ * - Production mode: a missing Storage connection string is fatal (the API is
+ *   useless without it); a missing Web PubSub connection string is a loud
+ *   warning (the SPA and read-only tracking can still serve, but live
+ *   broadcasting will fail until it is configured).
+ */
+
+export interface ServerConfigResult {
+  isDevMode: boolean;
+  fatal: string[];
+  warnings: string[];
+}
+
+function isDevMode(): boolean {
+  return process.env.DEV_MODE === 'true';
+}
+
+export function evaluateServerConfig(): ServerConfigResult {
+  const devMode = isDevMode();
+  const fatal: string[] = [];
+  const warnings: string[] = [];
+
+  const storageConn =
+    process.env.AZURE_STORAGE_CONNECTION_STRING ||
+    process.env.VITE_AZURE_STORAGE_CONNECTION_STRING;
+  const pubSubConn = process.env.AZURE_WEBPUBSUB_CONNECTION_STRING;
+
+  if (!storageConn) {
+    const msg =
+      'AZURE_STORAGE_CONNECTION_STRING is not set — data persistence will fail.';
+    if (devMode) warnings.push(`${msg} (dev mode: localStorage path may be used by the client)`);
+    else fatal.push(msg);
+  }
+
+  if (!pubSubConn) {
+    warnings.push(
+      'AZURE_WEBPUBSUB_CONNECTION_STRING is not set — real-time location broadcasting will not work.',
+    );
+  }
+
+  // Production auth: the backend validates Entra tokens; warn if absent.
+  if (!devMode) {
+    const entraMissing = ['VITE_ENTRA_TENANT_ID', 'VITE_ENTRA_CLIENT_ID'].filter(
+      (v) => !process.env[v],
+    );
+    if (entraMissing.length > 0) {
+      warnings.push(
+        `Entra config missing (${entraMissing.join(', ')}) — API token validation may reject all requests.`,
+      );
+    }
+  }
+
+  return { isDevMode: devMode, fatal, warnings };
+}
+
+/**
+ * Validate server configuration and log the result. In production, throws when
+ * fatal configuration is missing so the process fails fast on a bad deploy.
+ */
+export function validateServerEnv(): void {
+  const { isDevMode: devMode, fatal, warnings } = evaluateServerConfig();
+
+  for (const warning of warnings) {
+    console.warn(`[config] WARNING: ${warning}`);
+  }
+
+  if (fatal.length > 0) {
+    const message =
+      `[config] FATAL: invalid server configuration:\n` +
+      fatal.map((f) => `  • ${f}`).join('\n');
+    console.error(message);
+    throw new Error(message);
+  }
+
+  console.log(
+    `[config] Server configuration validated (mode: ${devMode ? 'development' : 'production'}, ${warnings.length} warning(s)).`,
+  );
+}

--- a/server/src/utils/storage.ts
+++ b/server/src/utils/storage.ts
@@ -15,6 +15,32 @@ const serviceClient = STORAGE_CONNECTION_STRING
   : null;
 
 /**
+ * Lightweight reachability probe for readiness checks. Lists at most one table
+ * to confirm the account is reachable. Never throws.
+ */
+export async function pingStorage(): Promise<StorageHealth> {
+  if (!serviceClient) {
+    return { configured: false, ok: false, error: 'connection string not configured' };
+  }
+  try {
+    const page = serviceClient.listTables().byPage({ maxPageSize: 1 });
+    await page.next();
+    return { configured: true, ok: true };
+  } catch (error) {
+    return { configured: true, ok: false, error: (error as Error).message };
+  }
+}
+
+export interface StorageHealth {
+  /** Whether a connection string is present. */
+  configured: boolean;
+  /** Whether the storage account responded to a lightweight request. */
+  ok: boolean;
+  /** Error detail when `ok` is false. */
+  error?: string;
+}
+
+/**
  * Get a TableClient and auto-create the table if it does not exist.
  */
 export async function getTableClient(tableName: string): Promise<TableClient> {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { initializeMockData } from './utils/mockData';
 import { useRoutes, useServiceWorker } from './hooks';
 import { ProtectedRoute } from './components';
 import { InstallBanner } from './components';
+import { ErrorBoundary } from './components';
 import type { Route as RouteType } from './types';
 
 // Lazy load pages for code splitting
@@ -133,6 +134,7 @@ function App() {
       
       {/* Main Routes */}
       <div style={{ paddingTop: isDevMode ? '2.5rem' : 0, height: '100%', width: '100%' }}>
+        <ErrorBoundary label="page">
         <Suspense fallback={<PageLoader />}>
           <Routes>
             {/* Public Routes */}
@@ -207,6 +209,7 @@ function App() {
             <Route path="*" element={<NotFound />} />
           </Routes>
         </Suspense>
+        </ErrorBoundary>
       </div>
     </BrowserRouter>
   );
@@ -257,15 +260,17 @@ function NavigationViewWrapper() {
   }
 
   return (
-    <NavigationView
-      route={route}
-      onExit={() => {
-        navigate('/dashboard');
-      }}
-      onComplete={() => {
-        navigate('/dashboard');
-      }}
-    />
+    <ErrorBoundary label="navigation view">
+      <NavigationView
+        route={route}
+        onExit={() => {
+          navigate('/dashboard');
+        }}
+        onComplete={() => {
+          navigate('/dashboard');
+        }}
+      />
+    </ErrorBoundary>
   );
 }
 
@@ -281,8 +286,12 @@ function RouteDetailWrapper() {
 function TrackingViewWrapper() {
   const pathSegments = window.location.pathname.split('/');
   const routeId = pathSegments[pathSegments.length - 1]; // /track/:id
-  
-  return <TrackingView routeId={routeId} />;
+
+  return (
+    <ErrorBoundary label="Santa tracker">
+      <TrackingView routeId={routeId} />
+    </ErrorBoundary>
+  );
 }
 
 // 404 Page

--- a/src/components/ErrorBoundary.css
+++ b/src/components/ErrorBoundary.css
@@ -1,0 +1,110 @@
+/**
+ * ErrorBoundary fallback styles.
+ * Uses the design tokens from src/index.css — no hardcoded brand hex.
+ */
+
+.error-boundary {
+  min-height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1.25rem;
+  text-align: center;
+}
+
+/* Full-screen variant for the top-level (app-wide) boundary. */
+.error-boundary--fullscreen {
+  min-height: 100vh;
+}
+
+.error-boundary__card {
+  max-width: 32rem;
+  width: 100%;
+  background: var(--candy-white);
+  border-radius: var(--border-radius);
+  box-shadow: var(--ui-shadow-emphasis);
+  padding: 2rem 1.5rem;
+}
+
+.error-boundary__emoji {
+  font-size: 3.5rem;
+  line-height: 1;
+  margin-bottom: 0.75rem;
+}
+
+.error-boundary__title {
+  font-family: var(--font-heading);
+  color: var(--fire-red);
+  font-size: 1.5rem;
+  margin: 0 0 0.5rem;
+}
+
+.error-boundary__message {
+  font-family: var(--font-body);
+  color: var(--neutral-800);
+  font-size: 1rem;
+  line-height: 1.6;
+  margin: 0 0 1.5rem;
+}
+
+.error-boundary__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.error-boundary__button {
+  font-family: var(--font-heading);
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0.65rem 1.4rem;
+  border-radius: var(--border-radius-sm);
+  border: none;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.error-boundary__button:active {
+  transform: translateY(1px);
+}
+
+.error-boundary__button:focus-visible {
+  outline: 3px solid var(--summer-gold-dark);
+  outline-offset: 2px;
+}
+
+.error-boundary__button--primary {
+  background: linear-gradient(135deg, var(--fire-red) 0%, var(--fire-red-dark) 100%);
+  color: var(--candy-white);
+  box-shadow: var(--ui-shadow);
+}
+
+.error-boundary__button--secondary {
+  background: var(--neutral-100);
+  color: var(--neutral-900);
+}
+
+/* Developer-only error detail; hidden visual noise kept compact. */
+.error-boundary__details {
+  margin-top: 1.5rem;
+  text-align: left;
+  background: var(--neutral-100);
+  border-radius: var(--border-radius-xs);
+  padding: 0.75rem 1rem;
+}
+
+.error-boundary__details summary {
+  cursor: pointer;
+  font-family: var(--font-body);
+  font-weight: 600;
+  color: var(--neutral-700);
+}
+
+.error-boundary__details pre {
+  margin: 0.5rem 0 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 0.8rem;
+  color: var(--neutral-800);
+}

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,110 @@
+/**
+ * ErrorBoundary component
+ *
+ * Catches render/lifecycle errors in its subtree and shows a friendly,
+ * on-brand fallback instead of a blank white screen. Errors are routed
+ * through `logClientError` so they can be wired to monitoring (#340).
+ *
+ * Usage:
+ *   <ErrorBoundary fullScreen>           // top-level, app-wide
+ *   <ErrorBoundary label="navigation">   // around a heavy route/page
+ *
+ * React error boundaries must be class components.
+ */
+
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { logClientError } from '../utils/errorLogger';
+import './ErrorBoundary.css';
+
+export interface ErrorBoundaryProps {
+  children: ReactNode;
+  /** Render the fallback at full viewport height (top-level boundary). */
+  fullScreen?: boolean;
+  /** Human-readable name of the area, used in logs and the reset hint. */
+  label?: string;
+  /**
+   * Custom fallback. Receives the error and a reset callback that clears the
+   * boundary so the subtree can attempt to re-render.
+   */
+  fallback?: (error: Error, reset: () => void) => ReactNode;
+  /** Optional extra hook for callers that want to react to the error. */
+  onError?: (error: Error, info: ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    logClientError(error, {
+      source: 'react-error-boundary',
+      componentStack: info.componentStack ?? undefined,
+      extra: { label: this.props.label },
+    });
+    this.props.onError?.(error, info);
+  }
+
+  reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): ReactNode {
+    const { error } = this.state;
+    const { children, fallback, fullScreen, label } = this.props;
+
+    if (error === null) return children;
+
+    if (fallback) return fallback(error, this.reset);
+
+    const isDev = import.meta.env.DEV;
+
+    return (
+      <div
+        className={`error-boundary${fullScreen ? ' error-boundary--fullscreen' : ''}`}
+        role="alert"
+        aria-live="assertive"
+      >
+        <div className="error-boundary__card">
+          <div className="error-boundary__emoji" role="img" aria-label="Surprised Santa">
+            🎅
+          </div>
+          <h1 className="error-boundary__title">Ho ho — something went wrong</h1>
+          <p className="error-boundary__message">
+            {label
+              ? `The ${label} ran into a problem.`
+              : 'Santa hit an unexpected snag.'}{' '}
+            You can try again, or head back to safety.
+          </p>
+          <div className="error-boundary__actions">
+            <button
+              type="button"
+              className="error-boundary__button error-boundary__button--primary"
+              onClick={this.reset}
+            >
+              Try again
+            </button>
+            <a
+              className="error-boundary__button error-boundary__button--secondary"
+              href="/"
+            >
+              Back to home
+            </a>
+          </div>
+          {isDev && (
+            <details className="error-boundary__details">
+              <summary>Error details (dev only)</summary>
+              <pre>{error.stack ?? error.message}</pre>
+            </details>
+          )}
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useState } from 'react';
+import { ErrorBoundary } from '../ErrorBoundary';
+
+/** Child that throws on first render, then succeeds after reset. */
+function Bomb({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error('boom');
+  }
+  return <div>recovered content</div>;
+}
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    // React logs caught errors to console.error; silence to keep test output clean.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders children when there is no error', () => {
+    render(
+      <ErrorBoundary>
+        <div>all good</div>
+      </ErrorBoundary>,
+    );
+    // getByText throws if absent, so reaching the assertion means it rendered.
+    expect(screen.getByText('all good')).toBeTruthy();
+  });
+
+  it('renders the fallback UI instead of crashing when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <Bomb shouldThrow />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByRole('alert')).toBeTruthy();
+    expect(screen.getByText(/something went wrong/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeTruthy();
+  });
+
+  it('mentions the provided label in the fallback message', () => {
+    render(
+      <ErrorBoundary label="Santa tracker">
+        <Bomb shouldThrow />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText(/Santa tracker/i)).toBeTruthy();
+  });
+
+  it('recovers when reset is clicked and the child no longer throws', () => {
+    function Wrapper() {
+      const [shouldThrow, setShouldThrow] = useState(true);
+      return (
+        <ErrorBoundary
+          fallback={(_error, reset) => (
+            <button
+              type="button"
+              onClick={() => {
+                setShouldThrow(false);
+                reset();
+              }}
+            >
+              retry
+            </button>
+          )}
+        >
+          <Bomb shouldThrow={shouldThrow} />
+        </ErrorBoundary>
+      );
+    }
+
+    render(<Wrapper />);
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+    expect(screen.getByText('recovered content')).toBeTruthy();
+  });
+
+  it('invokes onError and the global error sink', () => {
+    const onError = vi.fn();
+    const sink = vi.fn();
+    window.__onClientError = sink;
+
+    render(
+      <ErrorBoundary onError={onError}>
+        <Bomb shouldThrow />
+      </ErrorBoundary>,
+    );
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(sink).toHaveBeenCalledTimes(1);
+    const [reportedError, context] = sink.mock.calls[0];
+    expect(reportedError).toBeInstanceOf(Error);
+    expect(context.source).toBe('react-error-boundary');
+
+    delete window.__onClientError;
+  });
+});

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -24,6 +24,8 @@ export { RoutePreviewModal } from './RoutePreviewModal';
 export { OfflineBanner } from './OfflineBanner';
 export { SyncStatusBanner } from './SyncStatusBanner';
 export { InstallBanner } from './InstallBanner';
+export { ErrorBoundary } from './ErrorBoundary';
+export type { ErrorBoundaryProps } from './ErrorBoundary';
 
 // Convenience export for LoadingSkeleton (for consistency)
 export { DashboardSkeleton as LoadingSkeleton } from './LoadingSkeleton';

--- a/src/config/__tests__/env.test.ts
+++ b/src/config/__tests__/env.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { validateClientEnv, EnvironmentConfigError, isProductionMode } from '../env';
+import { EXAMPLE_MAPBOX_TOKEN } from '../mapbox';
+
+/**
+ * The global test setup stubs VITE_DEV_MODE=true and VITE_MAPBOX_TOKEN=test-token.
+ * Each test stubs the env it needs and restores afterwards.
+ */
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe('isProductionMode', () => {
+  it('is false when VITE_DEV_MODE=true', () => {
+    vi.stubEnv('VITE_DEV_MODE', 'true');
+    expect(isProductionMode()).toBe(false);
+  });
+
+  it('is true when VITE_DEV_MODE is not "true"', () => {
+    vi.stubEnv('VITE_DEV_MODE', 'false');
+    expect(isProductionMode()).toBe(true);
+  });
+});
+
+describe('validateClientEnv (development mode)', () => {
+  it('does not throw even with a placeholder Mapbox token', () => {
+    vi.stubEnv('VITE_DEV_MODE', 'true');
+    vi.stubEnv('VITE_MAPBOX_TOKEN', EXAMPLE_MAPBOX_TOKEN);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(() => validateClientEnv()).not.toThrow();
+  });
+});
+
+describe('validateClientEnv (production mode)', () => {
+  it('throws an aggregated error listing every missing/invalid var', () => {
+    vi.stubEnv('VITE_DEV_MODE', 'false');
+    vi.stubEnv('VITE_MAPBOX_TOKEN', EXAMPLE_MAPBOX_TOKEN); // placeholder => invalid
+    vi.stubEnv('VITE_ENTRA_CLIENT_ID', '');
+    vi.stubEnv('VITE_ENTRA_TENANT_ID', '');
+    vi.stubEnv('VITE_ENTRA_AUTHORITY', '');
+
+    let caught: unknown;
+    try {
+      validateClientEnv();
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(EnvironmentConfigError);
+    const err = caught as EnvironmentConfigError;
+    // One Mapbox problem + at least one Entra problem.
+    expect(err.problems.length).toBeGreaterThanOrEqual(2);
+    expect(err.problems.some((p) => p.includes('VITE_MAPBOX_TOKEN'))).toBe(true);
+    expect(err.problems.some((p) => p.toLowerCase().includes('entra'))).toBe(true);
+  });
+
+  it('rejects a secret ("sk.") Mapbox token in the browser', () => {
+    vi.stubEnv('VITE_DEV_MODE', 'false');
+    vi.stubEnv('VITE_MAPBOX_TOKEN', 'sk.this_is_a_secret_token');
+    // Provide valid Entra config so only the Mapbox problem remains.
+    vi.stubEnv('VITE_ENTRA_CLIENT_ID', 'client-123');
+    vi.stubEnv('VITE_ENTRA_TENANT_ID', 'tenant-123');
+    vi.stubEnv(
+      'VITE_ENTRA_AUTHORITY',
+      'https://login.microsoftonline.com/50fcb752-2a4e-4efd-bdc2-e18a5042c5a8',
+    );
+    vi.stubEnv('VITE_ENTRA_REDIRECT_URI', 'https://example.com/auth/callback');
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    expect(() => validateClientEnv()).toThrow(EnvironmentConfigError);
+  });
+
+  it('passes when Mapbox and Entra are correctly configured', () => {
+    vi.stubEnv('VITE_DEV_MODE', 'false');
+    vi.stubEnv('VITE_MAPBOX_TOKEN', 'pk.a_valid_public_token');
+    vi.stubEnv('VITE_ENTRA_CLIENT_ID', 'client-123');
+    vi.stubEnv('VITE_ENTRA_TENANT_ID', 'tenant-123');
+    vi.stubEnv(
+      'VITE_ENTRA_AUTHORITY',
+      'https://login.microsoftonline.com/50fcb752-2a4e-4efd-bdc2-e18a5042c5a8',
+    );
+    vi.stubEnv('VITE_ENTRA_REDIRECT_URI', 'https://example.com/auth/callback');
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    expect(() => validateClientEnv()).not.toThrow();
+  });
+});

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,90 @@
+/**
+ * Centralised client-side environment validation.
+ *
+ * `import.meta.env.*` is read across many modules; this is the single place
+ * that asserts the required variables are present and sane for the current
+ * mode. Call `validateClientEnv()` once at startup (see src/main.tsx).
+ *
+ * Behaviour:
+ * - Development mode (VITE_DEV_MODE=true): never throws — missing optional
+ *   config is logged as a warning so local dev stays zero-config.
+ * - Production mode (VITE_DEV_MODE!='true'): throws a single
+ *   `EnvironmentConfigError` aggregating every problem, so the app fails fast
+ *   with one clear message instead of scattered runtime failures.
+ */
+
+import { initializeMsalConfig } from '../auth/msalConfig';
+import { EXAMPLE_MAPBOX_TOKEN } from './mapbox';
+
+/** Aggregated, human-readable configuration error. */
+export class EnvironmentConfigError extends Error {
+  readonly problems: string[];
+
+  constructor(problems: string[]) {
+    super(
+      `Invalid environment configuration:\n${problems
+        .map((p) => `  • ${p}`)
+        .join('\n')}\n\nSee .env.example and docs/PRODUCTION_DEPLOYMENT_CHECKLIST.md.`,
+    );
+    this.name = 'EnvironmentConfigError';
+    this.problems = problems;
+  }
+}
+
+/** True when the app is running in production (auth + real backend) mode. */
+export function isProductionMode(): boolean {
+  return import.meta.env.VITE_DEV_MODE !== 'true';
+}
+
+function checkMapboxToken(problems: string[], isProd: boolean): void {
+  const token = import.meta.env.VITE_MAPBOX_TOKEN;
+
+  if (!token || token === EXAMPLE_MAPBOX_TOKEN) {
+    const message =
+      'VITE_MAPBOX_TOKEN is missing or set to the example placeholder — maps, geocoding and directions will not work.';
+    if (isProd) {
+      problems.push(message);
+    } else {
+      console.warn(`[env] ${message} (dev mode: continuing with placeholder)`);
+    }
+    return;
+  }
+
+  if (!token.startsWith('pk.')) {
+    problems.push(
+      'VITE_MAPBOX_TOKEN does not look like a public token (it should start with "pk."). Do not use a secret "sk." token in the browser.',
+    );
+  }
+}
+
+function checkEntraConfig(problems: string[]): void {
+  // initializeMsalConfig() validates Entra vars and throws a descriptive error
+  // in production mode; in dev mode it is a no-op aside from logging.
+  try {
+    initializeMsalConfig();
+  } catch (error) {
+    problems.push(error instanceof Error ? error.message : String(error));
+  }
+}
+
+/**
+ * Validate the client environment. Throws `EnvironmentConfigError` in
+ * production mode when required configuration is missing or invalid.
+ */
+export function validateClientEnv(): void {
+  const isProd = isProductionMode();
+  const problems: string[] = [];
+
+  checkMapboxToken(problems, isProd);
+  checkEntraConfig(problems);
+
+  if (problems.length > 0) {
+    throw new EnvironmentConfigError(problems);
+  }
+
+  if (import.meta.env.DEV) {
+    console.info(
+      `[env] Configuration validated (mode: ${isProd ? 'production' : 'development'}).`,
+    );
+  }
+}

--- a/src/config/mapbox.ts
+++ b/src/config/mapbox.ts
@@ -1,4 +1,8 @@
-export const MAPBOX_TOKEN = import.meta.env.VITE_MAPBOX_TOKEN || 'pk.eyJ1IjoiZXhhbXBsZSIsImEiOiJjbGV4YW1wbGUifQ.example';
+// Placeholder token used as a last-resort fallback. Treated as "not configured"
+// by the environment validator (src/config/env.ts).
+export const EXAMPLE_MAPBOX_TOKEN = 'pk.eyJ1IjoiZXhhbXBsZSIsImEiOiJjbGV4YW1wbGUifQ.example';
+
+export const MAPBOX_TOKEN = import.meta.env.VITE_MAPBOX_TOKEN || EXAMPLE_MAPBOX_TOKEN;
 
 // Default center for Australia (central Australia for fallback when no other location available)
 export const DEFAULT_CENTER: [number, number] = [133.7751, -25.2744]; // Central Australia

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,13 +7,18 @@ import './index.css'
 import App from './App.tsx'
 import { AuthProvider, BrigadeProvider } from './context'
 import { ErrorBoundary } from './components'
-import { installGlobalErrorHandlers } from './utils/errorLogger'
-import { validateClientEnv, EnvironmentConfigError } from './config/env'
+import { installGlobalErrorHandlers, installClientErrorReporter } from './utils/errorLogger'
+import { validateClientEnv, EnvironmentConfigError, isProductionMode } from './config/env'
 import { msalConfig, isMsalConfigured } from './auth/msalConfig'
 import './utils/fontLoader' // Initialize async font loading (CSP-compliant)
 
 // Capture uncaught errors and unhandled promise rejections app-wide.
 installGlobalErrorHandlers();
+
+// In production, forward client errors to the backend sink for monitoring.
+if (isProductionMode()) {
+  installClientErrorReporter();
+}
 
 // Create MSAL instance
 // In dev mode or when MSAL is not configured, we create a minimal instance

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,14 +8,12 @@ import App from './App.tsx'
 import { AuthProvider, BrigadeProvider } from './context'
 import { ErrorBoundary } from './components'
 import { installGlobalErrorHandlers } from './utils/errorLogger'
-import { msalConfig, isMsalConfigured, initializeMsalConfig } from './auth/msalConfig'
+import { validateClientEnv, EnvironmentConfigError } from './config/env'
+import { msalConfig, isMsalConfigured } from './auth/msalConfig'
 import './utils/fontLoader' // Initialize async font loading (CSP-compliant)
 
 // Capture uncaught errors and unhandled promise rejections app-wide.
 installGlobalErrorHandlers();
-
-// Initialize and validate MSAL configuration
-initializeMsalConfig();
 
 // Create MSAL instance
 // In dev mode or when MSAL is not configured, we create a minimal instance
@@ -39,10 +37,53 @@ const msalInstance = isMsalConfigured()
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (window as any).__msalInstance = msalInstance;
 
+/**
+ * Render a minimal, dependency-free fatal-configuration screen directly into
+ * #root. Used when environment validation fails in production so operators see
+ * a clear message instead of a blank white page.
+ */
+function renderFatalConfigError(error: unknown): void {
+  const problems =
+    error instanceof EnvironmentConfigError
+      ? error.problems
+      : [error instanceof Error ? error.message : String(error)];
+
+  const rootElement = document.getElementById('root');
+  if (rootElement) {
+    rootElement.innerHTML = `
+      <div style="min-height:100vh;display:flex;align-items:center;justify-content:center;padding:2rem;font-family:system-ui,sans-serif;background:#FAFAFA;color:#212121;">
+        <div style="max-width:34rem;width:100%;background:#fff;border-radius:16px;box-shadow:0 8px 24px rgba(0,0,0,0.2);padding:2rem;">
+          <div style="font-size:3rem;margin-bottom:0.5rem;">🎅🔧</div>
+          <h1 style="color:#D32F2F;font-size:1.4rem;margin:0 0 0.75rem;">Configuration problem</h1>
+          <p style="margin:0 0 1rem;line-height:1.6;">Fire Santa Run can't start because some required settings are missing or invalid:</p>
+          <ul style="margin:0 0 1rem;padding-left:1.25rem;line-height:1.6;">
+            ${problems.map((p) => `<li>${p.replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c] as string))}</li>`).join('')}
+          </ul>
+          <p style="margin:0;color:#616161;font-size:0.9rem;">See <code>.env.example</code> and <code>docs/PRODUCTION_DEPLOYMENT_CHECKLIST.md</code>.</p>
+        </div>
+      </div>`;
+  }
+
+  try {
+    document.getElementById('msal-loading')?.remove();
+  } catch {
+    /* no-op */
+  }
+}
+
 // Initialize MSAL and render app
 // CRITICAL: We must wait for handleRedirectPromise() to complete BEFORE rendering React
 // This prevents race conditions on iOS Safari where the app renders before auth completes
 async function initializeApp() {
+  // Fail fast on invalid configuration with a clear, user-visible message.
+  try {
+    validateClientEnv();
+  } catch (error) {
+    console.error('[env] Fatal configuration error:', error);
+    renderFatalConfigError(error);
+    return;
+  }
+
   if (isMsalConfigured()) {
     try {
       // Initialize MSAL instance

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,8 +6,13 @@ import { PublicClientApplication, EventType } from '@azure/msal-browser'
 import './index.css'
 import App from './App.tsx'
 import { AuthProvider, BrigadeProvider } from './context'
+import { ErrorBoundary } from './components'
+import { installGlobalErrorHandlers } from './utils/errorLogger'
 import { msalConfig, isMsalConfigured, initializeMsalConfig } from './auth/msalConfig'
 import './utils/fontLoader' // Initialize async font loading (CSP-compliant)
+
+// Capture uncaught errors and unhandled promise rejections app-wide.
+installGlobalErrorHandlers();
 
 // Initialize and validate MSAL configuration
 initializeMsalConfig();
@@ -80,13 +85,15 @@ async function initializeApp() {
   }
 
   createRoot(rootElement).render(
-    <MsalProvider instance={msalInstance}>
-      <AuthProvider>
-        <BrigadeProvider>
-          <App />
-        </BrigadeProvider>
-      </AuthProvider>
-    </MsalProvider>,
+    <ErrorBoundary fullScreen>
+      <MsalProvider instance={msalInstance}>
+        <AuthProvider>
+          <BrigadeProvider>
+            <App />
+          </BrigadeProvider>
+        </AuthProvider>
+      </MsalProvider>
+    </ErrorBoundary>,
   );
 
   // Remove the loading screen after React has mounted

--- a/src/utils/__tests__/errorLogger.test.ts
+++ b/src/utils/__tests__/errorLogger.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  logClientError,
+  shouldSample,
+  installClientErrorReporter,
+} from '../errorLogger';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete window.__onClientError;
+});
+
+describe('shouldSample', () => {
+  it('always samples at rate >= 1', () => {
+    expect(shouldSample(1)).toBe(true);
+    expect(shouldSample(2)).toBe(true);
+  });
+
+  it('never samples at rate <= 0', () => {
+    expect(shouldSample(0)).toBe(false);
+    expect(shouldSample(-1)).toBe(false);
+  });
+
+  it('samples based on the provided random value', () => {
+    expect(shouldSample(0.5, 0.4)).toBe(true);
+    expect(shouldSample(0.5, 0.6)).toBe(false);
+  });
+});
+
+describe('logClientError', () => {
+  it('invokes the registered sink with error and context', () => {
+    const sink = vi.fn();
+    window.__onClientError = sink;
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const err = new Error('boom');
+    logClientError(err, { source: 'test' });
+
+    expect(sink).toHaveBeenCalledWith(err, expect.objectContaining({ source: 'test' }));
+  });
+
+  it('never throws even if the sink throws', () => {
+    window.__onClientError = () => {
+      throw new Error('listener exploded');
+    };
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => logClientError(new Error('boom'), { source: 'test' })).not.toThrow();
+  });
+});
+
+describe('installClientErrorReporter', () => {
+  it('POSTs a sampled error report to the backend endpoint', () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    installClientErrorReporter({ endpoint: '/api/client-errors', sampleRate: 1 });
+    logClientError(new Error('kaboom'), { source: 'react-error-boundary' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/client-errors');
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body);
+    expect(body.message).toBe('kaboom');
+    expect(body.source).toBe('react-error-boundary');
+  });
+
+  it('does not POST when sampling excludes the error', () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    installClientErrorReporter({ sampleRate: 0 });
+    logClientError(new Error('dropped'), { source: 'test' });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('preserves a pre-existing sink', () => {
+    const existing = vi.fn();
+    window.__onClientError = existing;
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    installClientErrorReporter({ sampleRate: 1 });
+    logClientError(new Error('boom'), { source: 'test' });
+
+    expect(existing).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/errorLogger.ts
+++ b/src/utils/errorLogger.ts
@@ -63,3 +63,67 @@ export function installGlobalErrorHandlers(): void {
     logClientError(error, { source: 'unhandledrejection' });
   });
 }
+
+/**
+ * Decide whether a given error report should be sent, based on a sample rate
+ * in [0, 1]. Exposed for testing. 1 = always, 0 = never.
+ */
+export function shouldSample(sampleRate: number, random: number = Math.random()): boolean {
+  if (sampleRate >= 1) return true;
+  if (sampleRate <= 0) return false;
+  return random < sampleRate;
+}
+
+/**
+ * Install a best-effort reporter that forwards client errors to the backend
+ * sink (`POST /api/client-errors`), where App Service / App Insights captures
+ * them. Safe to call once at startup.
+ *
+ * Guards against feedback loops: a failure inside the reporter is swallowed and
+ * never re-reported, so a flaky network can't amplify into an error storm.
+ */
+export function installClientErrorReporter(options?: {
+  endpoint?: string;
+  sampleRate?: number;
+}): void {
+  if (typeof window === 'undefined') return;
+
+  const endpoint = options?.endpoint ?? '/api/client-errors';
+  const sampleRate = options?.sampleRate ?? 1;
+
+  // Preserve any existing subscriber (e.g. a test or future App Insights hook).
+  const existing = window.__onClientError;
+  let reporting = false;
+
+  window.__onClientError = (error, context) => {
+    existing?.(error, context);
+
+    // Never report while already inside a report (loop guard).
+    if (reporting) return;
+    if (!shouldSample(sampleRate)) return;
+
+    reporting = true;
+    try {
+      const payload = JSON.stringify({
+        message: error.message,
+        stack: error.stack,
+        source: context.source,
+        url: window.location.href,
+        userAgent: navigator.userAgent,
+      });
+      // keepalive lets the request survive a page unload after a fatal error.
+      void fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: payload,
+        keepalive: true,
+      }).catch(() => {
+        /* swallow — reporting failures must never re-trigger reporting */
+      });
+    } catch {
+      /* never throw from the reporter */
+    } finally {
+      reporting = false;
+    }
+  };
+}

--- a/src/utils/errorLogger.ts
+++ b/src/utils/errorLogger.ts
@@ -1,0 +1,65 @@
+/**
+ * errorLogger — minimal client-side error reporting seam.
+ *
+ * Today this logs to the console and exposes a hook (`window.__onClientError`)
+ * so non-React code and future monitoring can subscribe. The ErrorBoundary and
+ * global handlers route through here so there is a single place to wire up a
+ * real sink (Application Insights / backend endpoint) in #340 (observability).
+ */
+
+export interface ClientErrorContext {
+  /** Where the error originated, e.g. 'react-error-boundary', 'window.onerror'. */
+  source: string;
+  /** Optional React component stack or extra metadata. */
+  componentStack?: string;
+  /** Arbitrary extra context (route, brigadeId, etc.). */
+  extra?: Record<string, unknown>;
+}
+
+type ClientErrorListener = (error: Error, context: ClientErrorContext) => void;
+
+declare global {
+  interface Window {
+    /** Optional subscriber invoked for every reported client error. */
+    __onClientError?: ClientErrorListener;
+  }
+}
+
+/**
+ * Report a client-side error. Safe to call from anywhere; never throws.
+ */
+export function logClientError(error: Error, context: ClientErrorContext): void {
+  // Always surface in the console for local debugging.
+  console.error(`[client-error:${context.source}]`, error, context.extra ?? '');
+
+  // Hand off to an optional sink. Wrapped so a faulty listener can never
+  // break the calling code (e.g. the ErrorBoundary fallback render).
+  try {
+    window.__onClientError?.(error, context);
+  } catch (listenerError) {
+    console.error('[client-error] listener threw:', listenerError);
+  }
+}
+
+/**
+ * Install global handlers for uncaught errors and unhandled promise
+ * rejections. Idempotent — safe to call once at startup.
+ */
+export function installGlobalErrorHandlers(): void {
+  if (typeof window === 'undefined') return;
+  if ((window as unknown as { __globalErrorHandlersInstalled?: boolean }).__globalErrorHandlersInstalled) {
+    return;
+  }
+  (window as unknown as { __globalErrorHandlersInstalled?: boolean }).__globalErrorHandlersInstalled = true;
+
+  window.addEventListener('error', (event) => {
+    const error = event.error instanceof Error ? event.error : new Error(event.message);
+    logClientError(error, { source: 'window.onerror' });
+  });
+
+  window.addEventListener('unhandledrejection', (event) => {
+    const reason = event.reason;
+    const error = reason instanceof Error ? reason : new Error(String(reason));
+    logClientError(error, { source: 'unhandledrejection' });
+  });
+}


### PR DESCRIPTION
**Week 1** of the v1.0 Launch plan (#345) — the production-hardening foundation, delivered as one PR.

Closes #338 · Closes #339 · Closes #340

---

## ✅ #338 — Global ErrorBoundary + client error logging
The app no longer white-screens on an uncaught error.
- **`ErrorBoundary`** (`src/components/ErrorBoundary.tsx` + `.css`) — class component, on-brand festive fallback styled with `index.css` design tokens, `role="alert"`, **Try again** (resets) / **Back to home**, dev-only stack trace. Props: `fullScreen`, `label`, custom `fallback`, `onError`.
- **`errorLogger`** (`src/utils/errorLogger.ts`) — `logClientError()` seam + `installGlobalErrorHandlers()` for `window.onerror` / `unhandledrejection`; `window.__onClientError` subscriber hook.
- **Wiring** — full-screen boundary at app root (`main.tsx`), page-level boundary around the route tree (`App.tsx`), labelled boundaries around the two launch-critical map pages (public **Santa tracker**, **navigation view**).

## ✅ #339 — Centralised environment / config validation
Fail fast with one clear message instead of scattered runtime failures.
- **Client** (`src/config/env.ts`) — `validateClientEnv()` aggregates Mapbox + Entra checks into a single `EnvironmentConfigError`; rejects missing/placeholder Mapbox tokens and secret `sk.` tokens. `main.tsx` renders a **fatal-config screen** (not a blank page) when production config is invalid.
- **Server** (`server/src/utils/configValidation.ts`) — `validateServerEnv()` at startup: **fatal** if `AZURE_STORAGE_CONNECTION_STRING` missing in production, loud warnings for Web PubSub / Entra.
- **Docs** — `.env.example` documents server-side storage var; `PRODUCTION_DEPLOYMENT_CHECKLIST.md` gains a required-vars severity matrix.

## ✅ #340 — Observability: health/readiness + client error sink
- **`GET /api/health`** — cheap liveness (version, uptime); availability-test target. **`GET /api/ready`** — readiness; probes Table Storage reachability (`pingStorage`) + reports Web PubSub config, returns `503` when storage is down. Implemented in **both** `server/` (Hono) and `api/` (Functions).
- **`POST /api/client-errors`** — ingests client error reports, logs single-line `[client-error] {...}` JSON for App Service / App Insights.
- **Client** — `installClientErrorReporter()` wires the `window.__onClientError` seam to the backend in production (sampled, loop-guarded, `keepalive`, best-effort).
- **Docs** — monitoring section documents endpoints, availability-test target, and alert rules (the remaining Azure Monitor alert wiring is a documented manual deploy step).

---

## Verification
- `npm run lint` — clean
- `tsc -b` (app) + `tsc` (server) + `tsc` (api) — all pass
- `vite build` — pass
- `vitest run` — **487 tests pass** (468 baseline + 19 new across 3 new test files)

## New tests
- `ErrorBoundary.test.tsx` (fallback, label, reset/recovery, onError + sink)
- `config/env.test.ts` (dev-mode lenient, prod aggregation, `sk.` rejection, happy path)
- `errorLogger.test.ts` (sampling, sink invocation, reporter POST + loop/sink preservation)

https://claude.ai/code/session_01Jh7R81yYWFZNwe3ypBVcbt