### PR TITLE
Discovery UX uplift + navigation accessibility polish

### DIFF
--- a/src/components/NavigationPanel.tsx
+++ b/src/components/NavigationPanel.tsx
@@ -163,6 +163,7 @@ export function NavigationPanel({
             {waypointAfterNext && (
               <button
                 onClick={onSkipToNext}
+                aria-label={`Skip ahead to ${waypointAfterNext.name || waypointAfterNext.address || `stop ${waypointAfterNext.order}`}`}
                 style={{
                   flex: '1',
                   backgroundColor: '#FFA726',
@@ -187,6 +188,12 @@ export function NavigationPanel({
                 onMouseLeave={(e) => {
                   e.currentTarget.style.transform = 'scale(1)';
                 }}
+                onTouchStart={(e) => {
+                  e.currentTarget.style.transform = 'scale(0.95)';
+                }}
+                onTouchEnd={(e) => {
+                  e.currentTarget.style.transform = 'scale(1)';
+                }}
               >
                 <div style={{ fontSize: '0.7rem', color: '#424242', marginBottom: '0.25rem', fontWeight: 600 }}>
                   NEXT
@@ -206,6 +213,12 @@ export function NavigationPanel({
             <button
               onClick={onCompleteWaypoint}
               disabled={!canCompleteWaypoint}
+              aria-label={
+                canCompleteWaypoint
+                  ? `Mark ${nextWaypoint.name || 'current stop'} as arrived`
+                  : 'Get closer to the stop to mark it as arrived'
+              }
+              title={canCompleteWaypoint ? undefined : 'Get closer to the stop to enable'}
               style={{
                 flex: 1,
                 padding: '1rem',
@@ -227,6 +240,7 @@ export function NavigationPanel({
             </button>
             <button
               onClick={onStopNavigation}
+              aria-label="Stop navigation"
               style={{
                 padding: '1rem',
                 fontSize: '1rem',

--- a/src/pages/BrigadeDiscoveryPage.css
+++ b/src/pages/BrigadeDiscoveryPage.css
@@ -160,6 +160,38 @@
   line-height: 1;
 }
 
+.bdp__state-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 0.5rem;
+}
+
+.bdp__state-btn {
+  padding: 0.5rem 1.125rem;
+  min-height: 44px;
+  background: white;
+  color: var(--fire-red, #d32f2f);
+  border: 1.5px solid var(--fire-red, #d32f2f);
+  border-radius: var(--border-radius-xs);
+  font-weight: 700;
+  font-size: 0.875rem;
+  font-family: var(--font-body, 'Nunito', sans-serif);
+  cursor: pointer;
+  transition: background 0.18s, color 0.18s;
+}
+
+.bdp__state-btn:hover {
+  background: var(--fire-red, #d32f2f);
+  color: white;
+}
+
+.bdp__state-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(211, 47, 47, 0.3);
+}
+
 /* Card grid */
 .bdp__grid {
   display: grid;

--- a/src/pages/BrigadeDiscoveryPage.tsx
+++ b/src/pages/BrigadeDiscoveryPage.tsx
@@ -7,7 +7,7 @@
  * existing GET /api/brigades endpoint.
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useDeferredValue, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { storageAdapter } from '../storage';
 import { safeImageSrc } from '../utils/publicBrigade';
@@ -16,7 +16,8 @@ import type { Brigade } from '../storage/types';
 import './BrigadeDiscoveryPage.css';
 
 /** Extract the state abbreviation from "City, NSW" → "NSW". */
-function extractState(location: string): string {
+function extractState(location: string | undefined): string {
+  if (!location) return '';
   const parts = location.split(',');
   return parts.length > 1 ? parts[parts.length - 1].trim() : '';
 }
@@ -61,6 +62,16 @@ export function BrigadeDiscoveryPage() {
   const [query, setQuery] = useState('');
   const [stateFilter, setStateFilter] = useState('');
   const [showUnclaimed, setShowUnclaimed] = useState(false);
+  // Defer the query used for filtering so typing stays responsive even when the
+  // brigade list is large — the input updates instantly, the grid catches up.
+  const deferredQuery = useDeferredValue(query);
+
+  const hasActiveFilters = query.trim() !== '' || stateFilter !== '';
+
+  function clearFilters() {
+    setQuery('');
+    setStateFilter('');
+  }
 
   useEffect(() => {
     async function load() {
@@ -80,14 +91,14 @@ export function BrigadeDiscoveryPage() {
   }, []);
 
   const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
+    const q = deferredQuery.trim().toLowerCase();
     return brigades.filter((b) => {
       if (!showUnclaimed && !b.isClaimed) return false;
       if (stateFilter && extractState(b.location) !== stateFilter) return false;
-      if (q && !b.name.toLowerCase().includes(q) && !b.location.toLowerCase().includes(q)) return false;
+      if (q && !b.name.toLowerCase().includes(q) && !(b.location ?? '').toLowerCase().includes(q)) return false;
       return true;
     });
-  }, [brigades, query, stateFilter, showUnclaimed]);
+  }, [brigades, deferredQuery, stateFilter, showUnclaimed]);
 
   const statesWithBrigades = useMemo(() => {
     const present = new Set(brigades.map((b) => extractState(b.location)).filter(Boolean));
@@ -178,9 +189,25 @@ export function BrigadeDiscoveryPage() {
               <div className="bdp__state">
                 <div className="bdp__state-emoji">🔍</div>
                 <p>
-                  No brigades found{query || stateFilter ? ' for that search' : ''}. Try a
+                  No brigades found{hasActiveFilters ? ' for that search' : ''}. Try a
                   different name or state{!showUnclaimed ? ', or show unclaimed brigades' : ''}.
                 </p>
+                <div className="bdp__state-actions">
+                  {hasActiveFilters && (
+                    <button type="button" className="bdp__state-btn" onClick={clearFilters}>
+                      Clear search
+                    </button>
+                  )}
+                  {!showUnclaimed && (
+                    <button
+                      type="button"
+                      className="bdp__state-btn"
+                      onClick={() => setShowUnclaimed(true)}
+                    >
+                      Show unclaimed brigades
+                    </button>
+                  )}
+                </div>
               </div>
             ) : (
               <div className="bdp__grid">


### PR DESCRIPTION
Post-launch review pass over the recently-shipped public surfaces. Targeted, low-risk technical improvements plus a UX uplift on brigade discovery.

## UX uplift — Brigade Discovery (`/brigades`)
- **Actionable empty state.** When a search returns nothing, the page previously told users to "show unclaimed brigades" — but that toggle lives above the results, off-screen on small viewports. Now the no-results state offers one-tap **Clear search** and **Show unclaimed brigades** buttons right where the user is looking. (44px tap targets, focus-visible ring, design-token colours.)
- **Responsive typing.** Search filtering now runs off a deferred query (`useDeferredValue`), so the input stays snappy on large brigade lists while the grid catches up.

## Technical improvements
- **Navigation accessibility.** Added descriptive `aria-label`s to the Arrived / Stop / Skip-to-next buttons — screen-reader users now hear *why* "Arrived" is disabled (out of proximity range) instead of an unlabelled disabled control.
- **Touch press feedback.** The NEXT button's scale-on-press feedback was wired only to mouse events, so it never fired on this mobile-first app. Added `onTouchStart`/`onTouchEnd` parity.
- **Defensive location handling.** `extractState` and the name/location search now tolerate a missing `brigade.location` rather than throwing.

## Verification
- `tsc -b` clean · `eslint` clean
- 508 unit/integration tests pass · 14 a11y tests pass

## Deliberately not done
- **NavigationPanel inline-styles → CSS extraction** (flagged in review): a ~25-declaration refactor with regression risk immediately post-launch. Deferred as a follow-up.
- **OnboardingChecklist localStorage:** left as-is — a per-device UI dismissal flag is the correct use of localStorage and not subject to the brigade-data isolation rule.

https://claude.ai/code/session_01Jh7R81yYWFZNwe3ypBVcbt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jh7R81yYWFZNwe3ypBVcbt)_