### PR TITLE
Implement open issues: export/import, collaboration, predictive ETA, member mgmt + fix deploy build

### DIFF
--- a/api/src/routes.ts
+++ b/api/src/routes.ts
@@ -76,6 +76,11 @@ function entityToRoute(entity: any) {
     qrCodeUrl: entity.qrCodeUrl,
     viewCount: entity.viewCount || 0,
     archivedAt: entity.archivedAt || undefined,
+    navigationSettings: entity.navigationSettings ? JSON.parse(entity.navigationSettings) : undefined,
+    rerouteCount: entity.rerouteCount || 0,
+    updatedAt: entity.updatedAt || undefined,
+    lastEditedBy: entity.lastEditedBy ? JSON.parse(entity.lastEditedBy) : undefined,
+    comments: entity.comments ? JSON.parse(entity.comments) : undefined,
   };
   return route;
 }
@@ -106,6 +111,11 @@ function routeToEntity(route: any) {
     qrCodeUrl: route.qrCodeUrl || '',
     viewCount: route.viewCount || 0,
     archivedAt: route.archivedAt || '',
+    navigationSettings: route.navigationSettings ? JSON.stringify(route.navigationSettings) : '',
+    rerouteCount: route.rerouteCount || 0,
+    updatedAt: route.updatedAt || '',
+    lastEditedBy: route.lastEditedBy ? JSON.stringify(route.lastEditedBy) : '',
+    comments: route.comments ? JSON.stringify(route.comments) : '',
   };
 }
 

--- a/server/src/routes/routes.ts
+++ b/server/src/routes/routes.ts
@@ -46,6 +46,11 @@ function entityToRoute(entity: any) {
     qrCodeUrl: entity.qrCodeUrl,
     viewCount: entity.viewCount || 0,
     archivedAt: entity.archivedAt || undefined,
+    navigationSettings: entity.navigationSettings ? JSON.parse(entity.navigationSettings) : undefined,
+    rerouteCount: entity.rerouteCount || 0,
+    updatedAt: entity.updatedAt || undefined,
+    lastEditedBy: entity.lastEditedBy ? JSON.parse(entity.lastEditedBy) : undefined,
+    comments: entity.comments ? JSON.parse(entity.comments) : undefined,
   };
 }
 
@@ -74,6 +79,11 @@ function routeToEntity(route: any) {
     qrCodeUrl: route.qrCodeUrl || '',
     viewCount: route.viewCount || 0,
     archivedAt: route.archivedAt || '',
+    navigationSettings: route.navigationSettings ? JSON.stringify(route.navigationSettings) : '',
+    rerouteCount: route.rerouteCount || 0,
+    updatedAt: route.updatedAt || '',
+    lastEditedBy: route.lastEditedBy ? JSON.stringify(route.lastEditedBy) : '',
+    comments: route.comments ? JSON.stringify(route.comments) : '',
   };
 }
 

--- a/src/components/ExportMenu.tsx
+++ b/src/components/ExportMenu.tsx
@@ -1,0 +1,142 @@
+/**
+ * ExportMenu — modal offering JSON / CSV / KML downloads (and a print-friendly
+ * summary for a single route). Used from RouteDetail (single route) and the
+ * Dashboard (bulk export of all brigade routes).
+ */
+
+import { useEffect, useRef } from 'react';
+import type { Route } from '../types';
+import type { Brigade } from '../storage/types';
+import { exportRoute, exportRoutes, openPrintableRouteSummary } from '../utils/routeExport';
+import { COLORS, Z_INDEX } from '../utils/constants';
+
+export interface ExportMenuProps {
+  /** When set, exports just this route (and enables the print summary) */
+  route?: Route;
+  /** All routes — used for bulk export when `route` is not set */
+  routes?: Route[];
+  brigade?: Brigade | null;
+  onClose: () => void;
+}
+
+const FORMATS: Array<{ format: 'json' | 'csv' | 'kml'; icon: string; label: string; hint: string }> = [
+  { format: 'json', icon: '🗂️', label: 'JSON backup', hint: 'Full data — re-importable into Fire Santa Run' },
+  { format: 'csv', icon: '📊', label: 'CSV spreadsheet', hint: 'One row per stop — opens in Excel' },
+  { format: 'kml', icon: '🌏', label: 'KML', hint: 'Opens in Google Earth / Google My Maps' },
+];
+
+export function ExportMenu({ route, routes, brigade, onClose }: ExportMenuProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const isBulk = !route;
+  const count = isBulk ? (routes?.length ?? 0) : 1;
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKey);
+    dialogRef.current?.querySelector('button')?.focus();
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  const handleExport = (format: 'json' | 'csv' | 'kml') => {
+    if (route) {
+      exportRoute(route, format, brigade);
+    } else if (routes) {
+      exportRoutes(routes, format, brigade);
+    }
+    onClose();
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Export routes"
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0, 0, 0, 0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: Z_INDEX.modal,
+        padding: '1rem',
+      }}
+    >
+      <div
+        ref={dialogRef}
+        onClick={e => e.stopPropagation()}
+        style={{
+          background: 'white',
+          borderRadius: '16px',
+          boxShadow: '0 8px 32px rgba(0,0,0,0.25)',
+          padding: '1.5rem',
+          width: 'min(420px, 100%)',
+        }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.5rem' }}>
+          <h2 style={{ margin: 0, fontSize: '1.25rem', color: COLORS.fireRed }}>
+            📤 Export {isBulk ? `${count} route${count === 1 ? '' : 's'}` : `"${route!.name}"`}
+          </h2>
+          <button
+            onClick={onClose}
+            aria-label="Close export menu"
+            style={{
+              background: 'none', border: 'none', fontSize: '1.25rem', cursor: 'pointer',
+              color: COLORS.neutral700, minWidth: '44px', minHeight: '44px',
+            }}
+          >
+            ✕
+          </button>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+          {FORMATS.map(({ format, icon, label, hint }) => (
+            <button
+              key={format}
+              onClick={() => handleExport(format)}
+              disabled={count === 0}
+              style={{
+                display: 'flex', alignItems: 'center', gap: '0.75rem',
+                padding: '0.875rem 1rem', textAlign: 'left',
+                background: 'white', border: `2px solid ${COLORS.neutral300}`,
+                borderRadius: '12px', cursor: count === 0 ? 'not-allowed' : 'pointer',
+                opacity: count === 0 ? 0.5 : 1, transition: 'border-color 0.2s',
+              }}
+              onMouseEnter={e => { e.currentTarget.style.borderColor = COLORS.fireRed; }}
+              onMouseLeave={e => { e.currentTarget.style.borderColor = COLORS.neutral300; }}
+            >
+              <span style={{ fontSize: '1.5rem' }} aria-hidden="true">{icon}</span>
+              <span>
+                <span style={{ display: 'block', fontWeight: 600, color: COLORS.neutral900 }}>{label}</span>
+                <span style={{ display: 'block', fontSize: '0.8rem', color: COLORS.neutral700 }}>{hint}</span>
+              </span>
+            </button>
+          ))}
+
+          {route && (
+            <button
+              onClick={() => { openPrintableRouteSummary(route, brigade); onClose(); }}
+              style={{
+                display: 'flex', alignItems: 'center', gap: '0.75rem',
+                padding: '0.875rem 1rem', textAlign: 'left',
+                background: `linear-gradient(135deg, ${COLORS.christmasGreen} 0%, ${COLORS.eucalyptusGreen} 100%)`,
+                color: 'white', border: 'none', borderRadius: '12px', cursor: 'pointer',
+              }}
+            >
+              <span style={{ fontSize: '1.5rem' }} aria-hidden="true">🖨️</span>
+              <span>
+                <span style={{ display: 'block', fontWeight: 600 }}>Print / save as PDF</span>
+                <span style={{ display: 'block', fontSize: '0.8rem', opacity: 0.9 }}>
+                  Route summary with map, stops and instructions
+                </span>
+              </span>
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ImportModal.tsx
+++ b/src/components/ImportModal.tsx
@@ -1,0 +1,251 @@
+/**
+ * ImportModal — upload a JSON backup / GPX / KML file, preview the parsed
+ * routes with validation issues and duplicate detection, choose per-route
+ * conflict resolution, then confirm the import.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Route } from '../types';
+import {
+  parseImportFile,
+  markDuplicates,
+  resolveCandidate,
+  type ImportCandidate,
+} from '../utils/routeImport';
+import { COLORS, Z_INDEX } from '../utils/constants';
+
+export interface ImportModalProps {
+  brigadeId: string;
+  existingRoutes: Route[];
+  onClose: () => void;
+  /** Called with the resolved routes to persist; resolves when saved. */
+  onImport: (routes: Route[]) => Promise<void>;
+}
+
+const MAX_IMPORT_FILE_BYTES = 10 * 1024 * 1024; // 10 MB
+
+export function ImportModal({ brigadeId, existingRoutes, onClose, onImport }: ImportModalProps) {
+  const [candidates, setCandidates] = useState<ImportCandidate[] | null>(null);
+  const [errors, setErrors] = useState<string[]>([]);
+  const [isImporting, setIsImporting] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !isImporting) onClose();
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onClose, isImporting]);
+
+  const handleFile = useCallback(async (file: File) => {
+    setErrors([]);
+    setCandidates(null);
+    if (file.size > MAX_IMPORT_FILE_BYTES) {
+      setErrors(['File is too large (max 10 MB)']);
+      return;
+    }
+    try {
+      const content = await file.text();
+      const result = parseImportFile(file.name, content);
+      setErrors(result.errors);
+      if (result.candidates.length > 0) {
+        setCandidates(markDuplicates(result.candidates, existingRoutes));
+      }
+    } catch {
+      setErrors(['Could not read the selected file']);
+    }
+  }, [existingRoutes]);
+
+  const setResolution = (index: number, resolution: ImportCandidate['resolution']) => {
+    setCandidates(prev => prev?.map((c, i) => (i === index ? { ...c, resolution } : c)) ?? null);
+  };
+
+  const toImportCount = candidates?.filter(c => c.resolution !== 'skip').length ?? 0;
+
+  const handleConfirm = async () => {
+    if (!candidates) return;
+    setIsImporting(true);
+    try {
+      const routes = candidates
+        .map(c => resolveCandidate(c, brigadeId))
+        .filter((r): r is Route => r !== null);
+      await onImport(routes);
+      onClose();
+    } catch (err) {
+      setErrors([err instanceof Error ? err.message : 'Import failed — please try again']);
+      setIsImporting(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Import routes"
+      onClick={() => !isImporting && onClose()}
+      style={{
+        position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        zIndex: Z_INDEX.modal, padding: '1rem',
+      }}
+    >
+      <div
+        onClick={e => e.stopPropagation()}
+        style={{
+          background: 'white', borderRadius: '16px', boxShadow: '0 8px 32px rgba(0,0,0,0.25)',
+          padding: '1.5rem', width: 'min(560px, 100%)', maxHeight: '85vh', overflowY: 'auto',
+        }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.75rem' }}>
+          <h2 style={{ margin: 0, fontSize: '1.25rem', color: COLORS.fireRed }}>📥 Import routes</h2>
+          <button
+            onClick={onClose}
+            disabled={isImporting}
+            aria-label="Close import dialog"
+            style={{
+              background: 'none', border: 'none', fontSize: '1.25rem', cursor: 'pointer',
+              color: COLORS.neutral700, minWidth: '44px', minHeight: '44px',
+            }}
+          >
+            ✕
+          </button>
+        </div>
+
+        {!candidates && (
+          <>
+            <p style={{ color: COLORS.neutral700, fontSize: '0.9rem', marginTop: 0 }}>
+              Restore a Fire Santa Run JSON backup, or import routes from GPX / KML files.
+              You'll see a preview before anything is saved.
+            </p>
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              style={{
+                width: '100%', padding: '2rem 1rem',
+                border: `2px dashed ${COLORS.neutral300}`, borderRadius: '12px',
+                background: COLORS.sandLight, cursor: 'pointer',
+                fontSize: '1rem', fontWeight: 600, color: COLORS.neutral900,
+              }}
+            >
+              📁 Choose a .json, .gpx or .kml file
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".json,.gpx,.kml,application/json,application/gpx+xml,application/vnd.google-earth.kml+xml"
+              style={{ display: 'none' }}
+              onChange={e => {
+                const file = e.target.files?.[0];
+                if (file) handleFile(file);
+                e.target.value = '';
+              }}
+            />
+          </>
+        )}
+
+        {errors.length > 0 && (
+          <div
+            role="alert"
+            style={{
+              marginTop: '1rem', padding: '0.75rem 1rem', borderRadius: '8px',
+              background: '#FFEBEE', border: `1px solid ${COLORS.fireRedLight}`,
+              color: COLORS.fireRedDark, fontSize: '0.875rem',
+            }}
+          >
+            {errors.map((err, i) => <div key={i}>⚠️ {err}</div>)}
+          </div>
+        )}
+
+        {candidates && (
+          <>
+            <p style={{ color: COLORS.neutral700, fontSize: '0.9rem' }}>
+              Found <strong>{candidates.length}</strong> route{candidates.length === 1 ? '' : 's'}.
+              Review and confirm to import.
+            </p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+              {candidates.map((candidate, i) => (
+                <div
+                  key={candidate.route.id}
+                  style={{
+                    padding: '0.875rem 1rem', borderRadius: '12px',
+                    border: `1px solid ${candidate.duplicateOf ? COLORS.summerGold : COLORS.neutral200}`,
+                    background: candidate.resolution === 'skip' ? '#FAFAFA' : 'white',
+                    opacity: candidate.resolution === 'skip' ? 0.6 : 1,
+                  }}
+                >
+                  <div style={{ display: 'flex', justifyContent: 'space-between', gap: '0.5rem', flexWrap: 'wrap' }}>
+                    <div>
+                      <div style={{ fontWeight: 600, color: COLORS.neutral900 }}>🎄 {candidate.route.name}</div>
+                      <div style={{ fontSize: '0.8rem', color: COLORS.neutral700 }}>
+                        {candidate.route.date} · {candidate.route.waypoints.length} stops
+                        {candidate.route.geometry ? ' · has route path' : ''}
+                      </div>
+                    </div>
+                    {candidate.duplicateOf ? (
+                      <select
+                        value={candidate.resolution}
+                        onChange={e => setResolution(i, e.target.value as ImportCandidate['resolution'])}
+                        aria-label={`Duplicate resolution for ${candidate.route.name}`}
+                        style={{
+                          padding: '0.5rem', borderRadius: '8px',
+                          border: `1px solid ${COLORS.neutral300}`, fontSize: '0.875rem',
+                        }}
+                      >
+                        <option value="copy">Import as copy</option>
+                        <option value="replace">Replace existing</option>
+                        <option value="skip">Skip</option>
+                      </select>
+                    ) : (
+                      <label style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', fontSize: '0.875rem', color: COLORS.neutral700 }}>
+                        <input
+                          type="checkbox"
+                          checked={candidate.resolution !== 'skip'}
+                          onChange={e => setResolution(i, e.target.checked ? 'import' : 'skip')}
+                        />
+                        Import
+                      </label>
+                    )}
+                  </div>
+                  {candidate.issues.length > 0 && (
+                    <ul style={{ margin: '0.5rem 0 0', paddingLeft: '1.25rem', fontSize: '0.8rem', color: '#B26A00' }}>
+                      {candidate.issues.map((issue, j) => <li key={j}>{issue.message}</li>)}
+                    </ul>
+                  )}
+                </div>
+              ))}
+            </div>
+
+            <div style={{ display: 'flex', gap: '0.75rem', marginTop: '1.25rem' }}>
+              <button
+                onClick={() => { setCandidates(null); setErrors([]); }}
+                disabled={isImporting}
+                style={{
+                  flex: 1, padding: '0.875rem 1rem', background: 'white',
+                  border: `2px solid ${COLORS.neutral300}`, borderRadius: '12px',
+                  fontWeight: 600, cursor: 'pointer', color: COLORS.neutral900,
+                }}
+              >
+                ← Choose another file
+              </button>
+              <button
+                onClick={handleConfirm}
+                disabled={isImporting || toImportCount === 0}
+                style={{
+                  flex: 1, padding: '0.875rem 1rem',
+                  background: toImportCount === 0
+                    ? COLORS.neutral200
+                    : `linear-gradient(135deg, ${COLORS.christmasGreen} 0%, ${COLORS.eucalyptusGreen} 100%)`,
+                  color: toImportCount === 0 ? COLORS.neutral700 : 'white',
+                  border: 'none', borderRadius: '12px', fontWeight: 600,
+                  cursor: toImportCount === 0 ? 'not-allowed' : 'pointer',
+                }}
+              >
+                {isImporting ? 'Importing…' : `✓ Import ${toImportCount} route${toImportCount === 1 ? '' : 's'}`}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/RouteComments.tsx
+++ b/src/components/RouteComments.tsx
@@ -1,0 +1,198 @@
+/**
+ * RouteComments — brigade-internal comment thread on a route, with optional
+ * waypoint tagging. Comments live on the Route object so they sync through
+ * the normal storage adapters on both backends.
+ */
+
+import { useState } from 'react';
+import type { Route, RouteComment } from '../types';
+import { COLORS } from '../utils/constants';
+
+export interface RouteCommentsProps {
+  route: Route;
+  currentUser: { id: string; name: string } | null;
+  /** Persist the updated route (comments changed). */
+  onSave: (route: Route) => Promise<void>;
+}
+
+const MAX_COMMENT_LENGTH = 1000;
+
+function timeAgo(iso: string): string {
+  const seconds = Math.floor((Date.now() - new Date(iso).getTime()) / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+export function RouteComments({ route, currentUser, onSave }: RouteCommentsProps) {
+  const [text, setText] = useState('');
+  const [waypointId, setWaypointId] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const comments = [...(route.comments ?? [])].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+  );
+  const sortedWaypoints = [...route.waypoints].sort((a, b) => a.order - b.order);
+  const waypointName = (id: string) => {
+    const index = sortedWaypoints.findIndex(wp => wp.id === id);
+    if (index === -1) return 'removed stop';
+    return sortedWaypoints[index].name || `Stop ${index + 1}`;
+  };
+
+  const handleAdd = async () => {
+    if (!currentUser || !text.trim()) return;
+    setIsSaving(true);
+    setError(null);
+    const comment: RouteComment = {
+      id: `comment-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+      userId: currentUser.id,
+      userName: currentUser.name,
+      text: text.trim().slice(0, MAX_COMMENT_LENGTH),
+      waypointId: waypointId || undefined,
+      createdAt: new Date().toISOString(),
+    };
+    try {
+      await onSave({ ...route, comments: [...(route.comments ?? []), comment] });
+      setText('');
+      setWaypointId('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add comment');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async (commentId: string) => {
+    if (!confirm('Delete this comment?')) return;
+    setIsSaving(true);
+    setError(null);
+    try {
+      await onSave({ ...route, comments: (route.comments ?? []).filter(c => c.id !== commentId) });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete comment');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <section aria-label="Route comments">
+      <h3 style={{ margin: 0, marginBottom: '0.75rem', fontSize: '1rem', color: COLORS.neutral900 }}>
+        💬 Comments ({comments.length})
+      </h3>
+
+      {comments.length === 0 ? (
+        <p style={{ color: COLORS.neutral700, fontSize: '0.875rem' }}>
+          No comments yet — leave a note for your crew.
+        </p>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', marginBottom: '0.75rem' }}>
+          {comments.map(comment => (
+            <div
+              key={comment.id}
+              style={{
+                padding: '0.75rem',
+                backgroundColor: 'rgba(255, 255, 255, 0.9)',
+                borderRadius: '8px',
+                border: `1px solid ${COLORS.neutral200}`,
+              }}
+            >
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: '0.5rem', marginBottom: '0.25rem' }}>
+                <span style={{ fontWeight: 600, fontSize: '0.8rem', color: COLORS.neutral900 }}>
+                  {comment.userName}
+                  {comment.waypointId && (
+                    <span style={{
+                      marginLeft: '0.5rem', fontWeight: 600, fontSize: '0.7rem',
+                      background: COLORS.sandLight, color: '#B26A00',
+                      padding: '0.1rem 0.5rem', borderRadius: '999px',
+                    }}>
+                      📍 {waypointName(comment.waypointId)}
+                    </span>
+                  )}
+                </span>
+                <span style={{ fontSize: '0.75rem', color: COLORS.neutral700, whiteSpace: 'nowrap' }}>
+                  {timeAgo(comment.createdAt)}
+                </span>
+              </div>
+              <div style={{ fontSize: '0.875rem', color: COLORS.neutral900, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                {comment.text}
+              </div>
+              {currentUser?.id === comment.userId && (
+                <button
+                  onClick={() => handleDelete(comment.id)}
+                  disabled={isSaving}
+                  style={{
+                    marginTop: '0.25rem', background: 'none', border: 'none',
+                    color: COLORS.neutral700, fontSize: '0.75rem', cursor: 'pointer',
+                    padding: '0.25rem 0', textDecoration: 'underline',
+                  }}
+                >
+                  Delete
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {currentUser && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+          <textarea
+            value={text}
+            onChange={e => setText(e.target.value)}
+            placeholder="Add a comment for your brigade…"
+            maxLength={MAX_COMMENT_LENGTH}
+            rows={2}
+            aria-label="New comment"
+            style={{
+              width: '100%', boxSizing: 'border-box', padding: '0.6rem 0.75rem',
+              borderRadius: '8px', border: `1px solid ${COLORS.neutral300}`,
+              fontSize: '0.875rem', fontFamily: 'inherit', resize: 'vertical',
+            }}
+          />
+          <div style={{ display: 'flex', gap: '0.5rem' }}>
+            <select
+              value={waypointId}
+              onChange={e => setWaypointId(e.target.value)}
+              aria-label="Tag a stop (optional)"
+              style={{
+                flex: 1, padding: '0.5rem', borderRadius: '8px',
+                border: `1px solid ${COLORS.neutral300}`, fontSize: '0.8rem',
+                color: COLORS.neutral700, minHeight: '44px',
+              }}
+            >
+              <option value="">No stop tagged</option>
+              {sortedWaypoints.map((wp, i) => (
+                <option key={wp.id} value={wp.id}>📍 {wp.name || `Stop ${i + 1}`}</option>
+              ))}
+            </select>
+            <button
+              onClick={handleAdd}
+              disabled={isSaving || !text.trim()}
+              style={{
+                padding: '0.5rem 1rem', minHeight: '44px',
+                background: text.trim()
+                  ? `linear-gradient(135deg, ${COLORS.christmasGreen} 0%, ${COLORS.eucalyptusGreen} 100%)`
+                  : COLORS.neutral200,
+                color: text.trim() ? 'white' : COLORS.neutral700,
+                border: 'none', borderRadius: '8px', fontWeight: 600,
+                fontSize: '0.875rem', cursor: text.trim() ? 'pointer' : 'not-allowed',
+              }}
+            >
+              {isSaving ? 'Saving…' : 'Post'}
+            </button>
+          </div>
+          {error && (
+            <div role="alert" style={{ color: COLORS.error, fontSize: '0.8rem' }}>⚠️ {error}</div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -28,6 +28,12 @@ export { ErrorBoundary } from './ErrorBoundary';
 export type { ErrorBoundaryProps } from './ErrorBoundary';
 export { OnboardingChecklist } from './OnboardingChecklist';
 export type { OnboardingChecklistProps } from './OnboardingChecklist';
+export { ExportMenu } from './ExportMenu';
+export type { ExportMenuProps } from './ExportMenu';
+export { ImportModal } from './ImportModal';
+export type { ImportModalProps } from './ImportModal';
+export { RouteComments } from './RouteComments';
+export type { RouteCommentsProps } from './RouteComments';
 
 // Convenience export for LoadingSkeleton (for consistency)
 export { DashboardSkeleton as LoadingSkeleton } from './LoadingSkeleton';

--- a/src/hooks/useRoutes.ts
+++ b/src/hooks/useRoutes.ts
@@ -103,6 +103,16 @@ export function useRoutes() {
       route.brigadeId = brigadeIdToUse;
     }
 
+    // Stamp last-editor info for multi-operator conflict awareness
+    route.updatedAt = new Date().toISOString();
+    if (user) {
+      route.lastEditedBy = {
+        userId: user.id,
+        userName: user.name || user.email,
+        at: route.updatedAt,
+      };
+    }
+
     try {
       await storageAdapter.saveRoute(brigadeIdToUse, route);
       await loadRoutes();

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRoutes } from '../hooks';
-import { RouteStatusBadge, ShareModal, SEO, DashboardSkeleton, AppLayout, HighlightedText, OnboardingChecklist } from '../components';
+import { RouteStatusBadge, ShareModal, SEO, DashboardSkeleton, AppLayout, HighlightedText, OnboardingChecklist, ImportModal, ExportMenu } from '../components';
 import type { Route, RouteStatus } from '../types';
 import { formatDistance, formatDuration } from '../utils/mapbox';
 import {
@@ -19,10 +19,12 @@ import { format } from 'date-fns';
 
 export function Dashboard() {
   const navigate = useNavigate();
-  const { routes, isLoading, error, archiveRoute, restoreRoute } = useRoutes();
+  const { routes, isLoading, error, archiveRoute, restoreRoute, saveRoute } = useRoutes();
   const { brigade } = useBrigade();
   const [filterStatus, setFilterStatus] = useState<RouteStatus | 'all'>('all');
   const [shareModalRoute, setShareModalRoute] = useState<Route | null>(null);
+  const [importModalOpen, setImportModalOpen] = useState(false);
+  const [exportMenuOpen, setExportMenuOpen] = useState(false);
   const [archivingId, setArchivingId] = useState<string | null>(null);
   const [restoringId, setRestoringId] = useState<string | null>(null);
 
@@ -267,6 +269,58 @@ export function Dashboard() {
         >
           <span aria-hidden="true">🗂️</span> Templates
         </a>
+        <button
+          type="button"
+          onClick={() => setImportModalOpen(true)}
+          aria-label="Import routes from a backup, GPX or KML file"
+          style={{
+            padding: '0.875rem 1.25rem',
+            background: 'white',
+            color: 'var(--christmas-green)',
+            borderRadius: 'var(--border-radius-sm)',
+            fontWeight: 600,
+            fontFamily: 'var(--font-body)',
+            border: '2px solid var(--christmas-green)',
+            transition: 'all 0.3s ease',
+            fontSize: '1rem',
+            cursor: 'pointer',
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.background = 'var(--christmas-green)';
+            e.currentTarget.style.color = 'white';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.background = 'white';
+            e.currentTarget.style.color = 'var(--christmas-green)';
+          }}
+        >
+          <span aria-hidden="true">📥</span> Import
+        </button>
+        <button
+          type="button"
+          onClick={() => setExportMenuOpen(true)}
+          aria-label="Export all brigade routes"
+          style={{
+            padding: '0.875rem 1.25rem',
+            background: 'white',
+            color: 'var(--neutral-700)',
+            borderRadius: 'var(--border-radius-sm)',
+            fontWeight: 600,
+            fontFamily: 'var(--font-body)',
+            border: '2px solid var(--neutral-300)',
+            transition: 'all 0.3s ease',
+            fontSize: '1rem',
+            cursor: 'pointer',
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.borderColor = 'var(--neutral-700)';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.borderColor = 'var(--neutral-300)';
+          }}
+        >
+          <span aria-hidden="true">📤</span> Export
+        </button>
         </div>
       </div>
 
@@ -955,6 +1009,29 @@ export function Dashboard() {
           route={shareModalRoute}
           isOpen={true}
           onClose={() => setShareModalRoute(null)}
+        />
+      )}
+
+      {/* Import Modal (#153) */}
+      {importModalOpen && brigade && (
+        <ImportModal
+          brigadeId={brigade.id}
+          existingRoutes={routes}
+          onClose={() => setImportModalOpen(false)}
+          onImport={async (importedRoutes) => {
+            for (const route of importedRoutes) {
+              await saveRoute(route);
+            }
+          }}
+        />
+      )}
+
+      {/* Bulk Export Menu (#152) */}
+      {exportMenuOpen && (
+        <ExportMenu
+          routes={routes}
+          brigade={brigade}
+          onClose={() => setExportMenuOpen(false)}
         />
       )}
     </div>

--- a/src/pages/MemberManagementPage.tsx
+++ b/src/pages/MemberManagementPage.tsx
@@ -21,6 +21,8 @@ import {
   logMemberInvited,
   logMemberApproved,
   logMemberRemoved,
+  logRoleChanged,
+  logAuditEvent,
 } from '../utils/auditLog';
 
 const membershipService = new MembershipService(storageAdapter);
@@ -66,7 +68,7 @@ export function MemberManagementPage() {
       ]);
 
       setBrigade(brigadeData);
-      setMembers(membersData.filter(m => m.status === 'active'));
+      setMembers(membersData.filter(m => m.status === 'active' || m.status === 'suspended'));
       setPendingInvitations(invitationsData);
       setPendingApprovals(approvalsData);
     } catch (err) {
@@ -362,10 +364,20 @@ export function MemberManagementPage() {
                   onPromote={async () => {
                     if (!authUser || !brigadeId) return;
                     if (!confirm('Promote this member to admin? They will have full brigade management permissions.')) return;
-                    
+
                     try {
+                      const targetUser = await storageAdapter.getUser(membership.userId);
                       const result = await membershipService.promoteToAdmin(authUser.id, brigadeId, membership.userId);
                       if (result.success) {
+                        logRoleChanged(
+                          authUser.id,
+                          authUser.email,
+                          membership.userId,
+                          targetUser?.email || 'unknown',
+                          brigadeId,
+                          membership.role,
+                          'admin'
+                        );
                         await loadData();
                       } else {
                         alert(result.error || 'Failed to promote member');
@@ -378,10 +390,20 @@ export function MemberManagementPage() {
                   onDemote={async () => {
                     if (!authUser || !brigadeId) return;
                     if (!confirm('Demote this admin to operator? They will lose admin permissions.')) return;
-                    
+
                     try {
+                      const targetUser = await storageAdapter.getUser(membership.userId);
                       const result = await membershipService.demoteFromAdmin(authUser.id, brigadeId, membership.userId);
                       if (result.success) {
+                        logRoleChanged(
+                          authUser.id,
+                          authUser.email,
+                          membership.userId,
+                          targetUser?.email || 'unknown',
+                          brigadeId,
+                          'admin',
+                          'operator'
+                        );
                         await loadData();
                       } else {
                         alert(result.error || 'Failed to demote admin');
@@ -389,6 +411,53 @@ export function MemberManagementPage() {
                     } catch (err) {
                       console.error('Failed to demote admin:', err);
                       alert('Failed to demote admin');
+                    }
+                  }}
+                  onSuspend={async () => {
+                    if (!authUser || !brigadeId) return;
+                    if (!confirm('Suspend this member? They will lose access until reactivated.')) return;
+
+                    try {
+                      const targetUser = await storageAdapter.getUser(membership.userId);
+                      const result = await membershipService.suspendMember(authUser.id, brigadeId, membership.userId);
+                      if (result.success) {
+                        logAuditEvent('membership.removed', `${authUser.email} suspended ${targetUser?.email || 'unknown'}`, {
+                          userId: authUser.id,
+                          userEmail: authUser.email,
+                          brigadeId,
+                          targetUserId: membership.userId,
+                          metadata: { action: 'suspend', targetEmail: targetUser?.email },
+                        });
+                        await loadData();
+                      } else {
+                        alert(result.error || 'Failed to suspend member');
+                      }
+                    } catch (err) {
+                      console.error('Failed to suspend member:', err);
+                      alert('Failed to suspend member');
+                    }
+                  }}
+                  onReactivate={async () => {
+                    if (!authUser || !brigadeId) return;
+
+                    try {
+                      const targetUser = await storageAdapter.getUser(membership.userId);
+                      const result = await membershipService.reactivateMember(authUser.id, brigadeId, membership.userId);
+                      if (result.success) {
+                        logAuditEvent('membership.approved', `${authUser.email} reactivated ${targetUser?.email || 'unknown'}`, {
+                          userId: authUser.id,
+                          userEmail: authUser.email,
+                          brigadeId,
+                          targetUserId: membership.userId,
+                          metadata: { action: 'reactivate', targetEmail: targetUser?.email },
+                        });
+                        await loadData();
+                      } else {
+                        alert(result.error || 'Failed to reactivate member');
+                      }
+                    } catch (err) {
+                      console.error('Failed to reactivate member:', err);
+                      alert('Failed to reactivate member');
                     }
                   }}
                 />
@@ -544,6 +613,8 @@ function MemberCard({
   onRemove,
   onPromote,
   onDemote,
+  onSuspend,
+  onReactivate,
 }: {
   membership: BrigadeMembership;
   currentUserId?: string;
@@ -551,6 +622,8 @@ function MemberCard({
   onRemove: () => void;
   onPromote: () => void;
   onDemote: () => void;
+  onSuspend: () => void;
+  onReactivate: () => void;
 }) {
   const [user, setUser] = useState<User | null>(null);
 
@@ -559,6 +632,7 @@ function MemberCard({
   }, [membership.userId]);
 
   const isCurrentUser = currentUserId === membership.userId;
+  const isSuspended = membership.status === 'suspended';
 
   return (
     <div style={{
@@ -566,24 +640,76 @@ function MemberCard({
       justifyContent: 'space-between',
       alignItems: 'center',
       padding: '1rem',
-      backgroundColor: '#F5F5F5',
+      backgroundColor: isSuspended ? '#FFF3E0' : '#F5F5F5',
       borderRadius: '8px',
-      border: '1px solid #E0E0E0',
+      border: `1px solid ${isSuspended ? '#FFB74D' : '#E0E0E0'}`,
+      opacity: isSuspended ? 0.85 : 1,
     }}>
       <div>
         <div style={{ fontWeight: 600, marginBottom: '0.25rem' }}>
           {user?.name || 'Loading...'} {isCurrentUser && '(You)'}
+          {isSuspended && (
+            <span style={{
+              marginLeft: '0.5rem',
+              fontSize: '0.7rem',
+              fontWeight: 700,
+              color: '#B26A00',
+              background: '#FFE0B2',
+              padding: '0.15rem 0.5rem',
+              borderRadius: '999px',
+              verticalAlign: 'middle',
+            }}>
+              ⏸ SUSPENDED
+            </span>
+          )}
         </div>
         <div style={{ fontSize: '0.875rem', color: '#616161' }}>
           {user?.email}
+        </div>
+        <div style={{ fontSize: '0.75rem', color: '#9E9E9E', marginTop: '0.25rem' }}>
+          {membership.joinedAt && <>Joined {new Date(membership.joinedAt).toLocaleDateString()}</>}
+          {user?.lastLoginAt && <>{membership.joinedAt ? ' · ' : ''}Last login {new Date(user.lastLoginAt).toLocaleDateString()}</>}
         </div>
         <div style={{ marginTop: '0.5rem' }}>
           <RoleBadge role={membership.role} size="small" />
         </div>
       </div>
       {hasManagePermission && !isCurrentUser && (
-        <div style={{ display: 'flex', gap: '0.5rem' }}>
-          {membership.role !== 'admin' && (
+        <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', justifyContent: 'flex-end' }}>
+          {isSuspended ? (
+            <button
+              onClick={onReactivate}
+              style={{
+                padding: '0.5rem 1rem',
+                background: COLORS.success,
+                color: 'white',
+                border: 'none',
+                borderRadius: '8px',
+                fontSize: '0.875rem',
+                fontWeight: 600,
+                cursor: 'pointer',
+              }}
+            >
+              ▶️ Reactivate
+            </button>
+          ) : membership.role !== 'admin' ? (
+            <button
+              onClick={onSuspend}
+              style={{
+                padding: '0.5rem 1rem',
+                background: '#FB8C00',
+                color: 'white',
+                border: 'none',
+                borderRadius: '8px',
+                fontSize: '0.875rem',
+                fontWeight: 600,
+                cursor: 'pointer',
+              }}
+            >
+              ⏸ Suspend
+            </button>
+          ) : null}
+          {!isSuspended && membership.role !== 'admin' && (
             <button
               onClick={onPromote}
               style={{

--- a/src/pages/RouteDetail.tsx
+++ b/src/pages/RouteDetail.tsx
@@ -2,17 +2,23 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRoutes } from '../hooks';
 import { useTileCache } from '../hooks/useTileCache';
-import { 
-  MapView, 
-  RouteStatusBadge, 
-  ShareModal, 
+import { useAuth } from '../context';
+import {
+  MapView,
+  RouteStatusBadge,
+  ShareModal,
   RoutePreviewModal,
-  SEO, 
-  LoadingSkeleton
+  SEO,
+  LoadingSkeleton,
+  ExportMenu,
+  RouteComments
 } from '../components';
 import type { Route } from '../types';
+import type { Brigade } from '../storage/types';
+import { storageAdapter } from '../storage';
 import { formatDistance, formatDuration } from '../utils/mapbox';
 import { duplicateRoute } from '../utils/routeHelpers';
+import { predictRouteDuration, CONFIDENCE_LABELS } from '../utils/etaPrediction';
 import { format } from 'date-fns';
 import { COLORS, FLOATING_PANEL, Z_INDEX } from '../utils/constants';
 
@@ -22,8 +28,11 @@ export interface RouteDetailProps {
 
 export function RouteDetail({ routeId }: RouteDetailProps) {
   const navigate = useNavigate();
-  const { getRoute, deleteRoute, saveRoute, archiveRoute, restoreRoute } = useRoutes();
+  const { routes, getRoute, deleteRoute, saveRoute, archiveRoute, restoreRoute } = useRoutes();
+  const { user } = useAuth();
   const [route, setRoute] = useState<Route | null>(null);
+  const [brigade, setBrigade] = useState<Brigade | null>(null);
+  const [exportMenuOpen, setExportMenuOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const [shareModalOpen, setShareModalOpen] = useState(false);
@@ -45,6 +54,9 @@ export function RouteDetail({ routeId }: RouteDetailProps) {
       try {
         const loadedRoute = await getRoute(routeId);
         setRoute(loadedRoute);
+        if (loadedRoute?.brigadeId) {
+          storageAdapter.getBrigade(loadedRoute.brigadeId).then(setBrigade).catch(() => setBrigade(null));
+        }
       } catch (err) {
         const error = err instanceof Error ? err : new Error('Failed to load route');
         setError(error);
@@ -132,9 +144,15 @@ export function RouteDetail({ routeId }: RouteDetailProps) {
       updatedRoute.startedAt = new Date().toISOString();
     }
     
-    // If completing, set completedAt timestamp
+    // If completing, set completedAt timestamp and record the actual duration
+    // so the predictive ETA model (#145) learns from this run
     if (newStatus === 'completed' && !route.completedAt) {
       updatedRoute.completedAt = new Date().toISOString();
+      if (!updatedRoute.actualDuration && route.startedAt) {
+        updatedRoute.actualDuration = Math.round(
+          (Date.now() - new Date(route.startedAt).getTime()) / 1000
+        );
+      }
     }
     
     setRoute(updatedRoute);
@@ -196,6 +214,10 @@ export function RouteDetail({ routeId }: RouteDetailProps) {
 
   const canNavigate = route.geometry && route.navigationSteps && route.navigationSteps.length > 0;
   const canShare = route.status === 'published' || route.status === 'active' || route.status === 'completed';
+  // Predictive ETA (#145): adjust the estimate using the brigade's completed-run history
+  const etaPrediction = route.status !== 'completed' && route.status !== 'archived'
+    ? predictRouteDuration(route, routes)
+    : null;
 
   return (
     <>
@@ -333,6 +355,19 @@ export function RouteDetail({ routeId }: RouteDetailProps) {
               </div>
               <div style={{ color: COLORS.neutral700, fontSize: '0.75rem' }}>Duration</div>
             </div>
+            {etaPrediction && (
+              <div style={{ textAlign: 'center' }} title={CONFIDENCE_LABELS[etaPrediction.confidence]}>
+                <div style={{ fontWeight: 600, color: COLORS.oceanBlue, fontSize: '1.25rem' }}>
+                  {formatDuration(etaPrediction.duration)}
+                  <span aria-hidden="true" style={{ fontSize: '0.75rem', marginLeft: '0.25rem' }}>
+                    {etaPrediction.confidence === 'high' ? '●●●' : etaPrediction.confidence === 'medium' ? '●●○' : '●○○'}
+                  </span>
+                </div>
+                <div style={{ color: COLORS.neutral700, fontSize: '0.75rem' }}>
+                  Predicted ({etaPrediction.sampleCount} past run{etaPrediction.sampleCount === 1 ? '' : 's'})
+                </div>
+              </div>
+            )}
             <div style={{ textAlign: 'center' }}>
               <div style={{ fontWeight: 600, color: COLORS.neutral900, fontSize: '1.25rem' }}>
                 {route.date ? format(new Date(route.date), 'MMM dd') : '—'}
@@ -447,7 +482,22 @@ export function RouteDetail({ routeId }: RouteDetailProps) {
                 {route.archivedAt && (
                   <div>📦 Archived: {format(new Date(route.archivedAt), 'MMM dd, h:mm a')}</div>
                 )}
+                {route.lastEditedBy && (
+                  <div>✏️ Last edited by {route.lastEditedBy.userName}: {format(new Date(route.lastEditedBy.at), 'MMM dd, h:mm a')}</div>
+                )}
               </div>
+            </div>
+
+            {/* Comments (#151 — brigade collaboration) */}
+            <div style={{ marginTop: '1.5rem', paddingTop: '1rem', borderTop: `1px solid ${COLORS.neutral200}` }}>
+              <RouteComments
+                route={route}
+                currentUser={user ? { id: user.id, name: user.name || user.email } : null}
+                onSave={async (updated) => {
+                  await saveRoute(updated);
+                  setRoute(updated);
+                }}
+              />
             </div>
           </div>
         )}
@@ -627,6 +677,32 @@ export function RouteDetail({ routeId }: RouteDetailProps) {
               }}
             >
               📊 Analytics
+            </button>
+
+            {/* Export Button */}
+            <button
+              onClick={() => setExportMenuOpen(true)}
+              style={{
+                padding: '0.875rem 1rem',
+                background: 'white',
+                color: COLORS.neutral900,
+                border: `2px solid ${COLORS.neutral300}`,
+                borderRadius: FLOATING_PANEL.borderRadius.button,
+                fontSize: '0.875rem',
+                fontWeight: 600,
+                cursor: 'pointer',
+                transition: 'all 0.2s',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.borderColor = COLORS.christmasGreen;
+                e.currentTarget.style.color = COLORS.christmasGreen;
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.borderColor = COLORS.neutral300;
+                e.currentTarget.style.color = COLORS.neutral900;
+              }}
+            >
+              📤 Export
             </button>
           </div>
 
@@ -906,6 +982,15 @@ export function RouteDetail({ routeId }: RouteDetailProps) {
           route={route}
           isOpen={true}
           onClose={() => setShareModalOpen(false)}
+        />
+      )}
+
+      {/* Export Menu Modal */}
+      {exportMenuOpen && (
+        <ExportMenu
+          route={route}
+          brigade={brigade}
+          onClose={() => setExportMenuOpen(false)}
         />
       )}
 

--- a/src/pages/RouteEditor.tsx
+++ b/src/pages/RouteEditor.tsx
@@ -150,6 +150,25 @@ export function RouteEditor({ routeId, mode }: RouteEditorProps) {
     setSaveError(null);
 
     try {
+      // Multi-operator conflict detection: warn if someone else saved this
+      // route since we loaded it (last-edit-wins after confirmation).
+      try {
+        const stored = await getRoute(route.id);
+        if (stored?.updatedAt && stored.updatedAt !== route.updatedAt) {
+          const who = stored.lastEditedBy?.userName || 'Another member';
+          const overwrite = confirm(
+            `${who} saved changes to this route while you were editing. ` +
+            'Saving now will overwrite their changes. Continue?'
+          );
+          if (!overwrite) {
+            setIsSaving(false);
+            return;
+          }
+        }
+      } catch {
+        // Conflict check is best-effort; never block saving on it
+      }
+
       const routeToSave: Route = {
         ...route,
         status: shouldPublish ? 'published' : route.status,
@@ -169,7 +188,7 @@ export function RouteEditor({ routeId, mode }: RouteEditorProps) {
     } finally {
       setIsSaving(false);
     }
-  }, [route, validate, saveRoute, navigate]);
+  }, [route, validate, saveRoute, getRoute, navigate]);
 
   const handleSaveAsTemplate = useCallback(async () => {
     if (!route.name.trim()) {

--- a/src/services/membershipService.ts
+++ b/src/services/membershipService.ts
@@ -458,9 +458,83 @@ export class MembershipService {
   }
 
   /**
+   * Suspend an active member (admin only).
+   * Suspended members keep their record but lose access until reactivated.
+   * Admins cannot be suspended — demote them first.
+   *
+   * @param adminId - Admin performing the suspension
+   * @param brigadeId - Brigade ID
+   * @param userId - Member to suspend
+   * @returns Service result
+   */
+  async suspendMember(
+    adminId: string,
+    brigadeId: string,
+    userId: string
+  ): Promise<ServiceResult> {
+    const adminMembership = await this.storage.getMembership(brigadeId, adminId);
+    if (!adminMembership || adminMembership.role !== 'admin') {
+      return { success: false, error: 'Only admins can suspend members' };
+    }
+    if (adminId === userId) {
+      return { success: false, error: 'You cannot suspend yourself' };
+    }
+
+    const membership = await this.storage.getMembership(brigadeId, userId);
+    if (!membership) {
+      return { success: false, error: 'Membership not found' };
+    }
+    if (membership.role === 'admin') {
+      return { success: false, error: 'Admins cannot be suspended — demote them first' };
+    }
+    if (membership.status !== 'active') {
+      return { success: false, error: 'Only active members can be suspended' };
+    }
+
+    membership.status = 'suspended';
+    membership.updatedAt = new Date().toISOString();
+    await this.storage.saveMembership(membership);
+
+    return { success: true };
+  }
+
+  /**
+   * Reactivate a suspended member (admin only).
+   *
+   * @param adminId - Admin performing the reactivation
+   * @param brigadeId - Brigade ID
+   * @param userId - Member to reactivate
+   * @returns Service result
+   */
+  async reactivateMember(
+    adminId: string,
+    brigadeId: string,
+    userId: string
+  ): Promise<ServiceResult> {
+    const adminMembership = await this.storage.getMembership(brigadeId, adminId);
+    if (!adminMembership || adminMembership.role !== 'admin') {
+      return { success: false, error: 'Only admins can reactivate members' };
+    }
+
+    const membership = await this.storage.getMembership(brigadeId, userId);
+    if (!membership) {
+      return { success: false, error: 'Membership not found' };
+    }
+    if (membership.status !== 'suspended') {
+      return { success: false, error: 'Only suspended members can be reactivated' };
+    }
+
+    membership.status = 'active';
+    membership.updatedAt = new Date().toISOString();
+    await this.storage.saveMembership(membership);
+
+    return { success: true };
+  }
+
+  /**
    * Leave a brigade (self-service).
    * Validates that leaving won't violate admin constraints.
-   * 
+   *
    * @param userId - User leaving the brigade
    * @param brigadeId - Brigade to leave
    * @returns Service result

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,6 +30,27 @@ export interface NavigationSettings {
   transitSpeedKmh: number;        // Speed for high-speed road segments in km/h (default: 60)
 }
 
+/** A comment left by a brigade member on a route (optionally tagged to a waypoint). */
+export interface RouteComment {
+  id: string;
+  /** User ID of the author */
+  userId: string;
+  /** Display name of the author (denormalised for display without a user lookup) */
+  userName: string;
+  /** Comment body (plain text) */
+  text: string;
+  /** Optional waypoint this comment is attached to */
+  waypointId?: string;
+  createdAt: string;
+}
+
+/** Who last saved a route — used for multi-operator conflict awareness. */
+export interface RouteEditStamp {
+  userId: string;
+  userName: string;
+  at: string;
+}
+
 export interface Route {
   id: string;
   brigadeId: string;
@@ -56,6 +77,12 @@ export interface Route {
   viewCount?: number;
   archivedAt?: string;
   rerouteCount?: number;
+  /** Last-save timestamp — used for multi-operator conflict detection */
+  updatedAt?: string;
+  /** Who last saved this route */
+  lastEditedBy?: RouteEditStamp;
+  /** Brigade-internal comment thread */
+  comments?: RouteComment[];
 }
 
 export interface RouteTemplate {

--- a/src/utils/__tests__/etaPrediction.test.ts
+++ b/src/utils/__tests__/etaPrediction.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for predictive ETA utilities
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildEtaModel, predictDuration, predictRouteDuration, sampleFromRoute } from '../etaPrediction';
+import type { Route } from '../../types';
+
+function completedRoute(estimated: number, actual: number, overrides: Partial<Route> = {}): Route {
+  return {
+    id: `route-${Math.random().toString(36).slice(2)}`,
+    brigadeId: 'brigade-1',
+    name: 'Past Run',
+    date: '2025-12-24',
+    startTime: '18:00',
+    status: 'completed',
+    waypoints: [],
+    estimatedDuration: estimated,
+    actualDuration: actual,
+    createdAt: '2025-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('etaPrediction', () => {
+  describe('sampleFromRoute', () => {
+    it('extracts the actual/estimated factor from a completed route', () => {
+      const sample = sampleFromRoute(completedRoute(3600, 4320));
+      expect(sample?.factor).toBeCloseTo(1.2);
+      expect(sample?.startHour).toBe(18);
+    });
+
+    it('ignores drafts and routes without timing data', () => {
+      expect(sampleFromRoute(completedRoute(3600, 4320, { status: 'draft' }))).toBeNull();
+      expect(sampleFromRoute(completedRoute(0, 4320))).toBeNull();
+      expect(sampleFromRoute(completedRoute(3600, 0))).toBeNull();
+    });
+
+    it('discards outliers (paused/abandoned runs)', () => {
+      expect(sampleFromRoute(completedRoute(3600, 3600 * 10))).toBeNull();
+    });
+  });
+
+  describe('buildEtaModel', () => {
+    it('returns a neutral model with no history', () => {
+      const model = buildEtaModel([]);
+      expect(model.overallFactor).toBe(1);
+      expect(model.samples).toHaveLength(0);
+    });
+
+    it('uses the median factor, robust to a single slow run', () => {
+      const model = buildEtaModel([
+        completedRoute(3600, 3600),
+        completedRoute(3600, 3700),
+        completedRoute(3600, 3600 * 2.5),
+      ]);
+      expect(model.overallFactor).toBeCloseTo(3700 / 3600);
+    });
+  });
+
+  describe('predictDuration', () => {
+    it('is low confidence with no samples and returns the base estimate', () => {
+      const prediction = predictDuration(3600, buildEtaModel([]));
+      expect(prediction.duration).toBe(3600);
+      expect(prediction.confidence).toBe('low');
+    });
+
+    it('is high confidence with many consistent samples', () => {
+      const routes = Array.from({ length: 6 }, () => completedRoute(3600, 4300 + Math.round(Math.random() * 40)));
+      const model = buildEtaModel(routes);
+      const prediction = predictDuration(3600, model);
+      expect(prediction.confidence).toBe('high');
+      expect(prediction.duration).toBeGreaterThan(4200);
+      expect(prediction.sampleCount).toBe(6);
+    });
+
+    it('is low/medium confidence when history is inconsistent', () => {
+      const model = buildEtaModel([
+        completedRoute(3600, 1800),
+        completedRoute(3600, 7200),
+        completedRoute(3600, 3600),
+        completedRoute(3600, 5400),
+        completedRoute(3600, 2400),
+      ]);
+      const prediction = predictDuration(3600, model);
+      expect(prediction.confidence).not.toBe('high');
+    });
+
+    it('blends time-of-day factor when the start hour has history', () => {
+      const routes = [
+        completedRoute(3600, 3600, { startTime: '10:00' }),
+        completedRoute(3600, 3600, { startTime: '10:00' }),
+        completedRoute(3600, 5400, { startTime: '19:00' }),
+        completedRoute(3600, 5400, { startTime: '19:00' }),
+      ];
+      const model = buildEtaModel(routes);
+      const evening = predictDuration(3600, model, 19);
+      const morning = predictDuration(3600, model, 10);
+      expect(evening.duration).toBeGreaterThan(morning.duration);
+    });
+  });
+
+  describe('predictRouteDuration', () => {
+    it('excludes the route itself from its own model', () => {
+      const target = completedRoute(3600, 7200, { id: 'target' });
+      expect(predictRouteDuration(target, [target])).toBeNull();
+    });
+
+    it('predicts using sibling route history', () => {
+      const target = completedRoute(3600, 0, { id: 'target', status: 'published', actualDuration: undefined });
+      const history = [completedRoute(3600, 4320), completedRoute(1800, 2160), completedRoute(7200, 8640)];
+      const prediction = predictRouteDuration(target, [target, ...history]);
+      expect(prediction).not.toBeNull();
+      expect(prediction!.factor).toBeCloseTo(1.2);
+      expect(prediction!.duration).toBe(Math.round(3600 * prediction!.factor));
+    });
+  });
+});

--- a/src/utils/__tests__/routeExport.test.ts
+++ b/src/utils/__tests__/routeExport.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for route export utilities
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  routesToBackupJSON,
+  routesToCSV,
+  routesToKML,
+  safeFilename,
+  BACKUP_FORMAT,
+} from '../routeExport';
+import type { Route } from '../../types';
+
+function makeRoute(overrides: Partial<Route> = {}): Route {
+  return {
+    id: 'route-1',
+    brigadeId: 'brigade-1',
+    name: 'Test Route',
+    date: '2026-12-24',
+    startTime: '18:00',
+    status: 'draft',
+    waypoints: [
+      { id: 'wp-1', coordinates: [151.2, -33.8], name: 'Start', address: '1 Main St', order: 0, isCompleted: false },
+      { id: 'wp-2', coordinates: [151.3, -33.9], name: 'End, "quoted"', order: 1, isCompleted: true, notes: 'ho ho' },
+    ],
+    geometry: { type: 'LineString', coordinates: [[151.2, -33.8], [151.25, -33.85], [151.3, -33.9]] },
+    distance: 12000,
+    estimatedDuration: 3600,
+    createdAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('routeExport', () => {
+  describe('safeFilename', () => {
+    it('sanitises unsafe characters and lowercases', () => {
+      expect(safeFilename('My Route! (2026) <v2>')).toBe('my-route-2026-v2');
+    });
+
+    it('falls back to "route" when nothing survives', () => {
+      expect(safeFilename('###')).toBe('route');
+    });
+  });
+
+  describe('routesToBackupJSON', () => {
+    it('wraps routes in a versioned backup envelope', () => {
+      const backup = JSON.parse(routesToBackupJSON([makeRoute()], { id: 'brigade-1', name: 'Griffith RFS' }));
+      expect(backup.format).toBe(BACKUP_FORMAT);
+      expect(backup.version).toBe(1);
+      expect(backup.brigadeId).toBe('brigade-1');
+      expect(backup.brigadeName).toBe('Griffith RFS');
+      expect(backup.routes).toHaveLength(1);
+      expect(backup.routes[0].waypoints).toHaveLength(2);
+    });
+  });
+
+  describe('routesToCSV', () => {
+    it('emits one row per waypoint with route metadata', () => {
+      const csv = routesToCSV([makeRoute()]);
+      const lines = csv.split('\r\n');
+      expect(lines).toHaveLength(3); // header + 2 waypoints
+      expect(lines[0]).toContain('route_name');
+      expect(lines[1]).toContain('Test Route');
+      expect(lines[1]).toContain('151.2');
+    });
+
+    it('escapes quotes and commas per RFC 4180', () => {
+      const csv = routesToCSV([makeRoute()]);
+      expect(csv).toContain('"End, ""quoted"""');
+    });
+
+    it('emits a single metadata row for a route without waypoints', () => {
+      const csv = routesToCSV([makeRoute({ waypoints: [] })]);
+      expect(csv.split('\r\n')).toHaveLength(2);
+    });
+  });
+
+  describe('routesToKML', () => {
+    it('produces placemarks for waypoints and a path for geometry', () => {
+      const kml = routesToKML([makeRoute()]);
+      expect(kml).toContain('<kml');
+      expect(kml).toContain('<name>Start</name>');
+      expect(kml).toContain('<LineString>');
+      expect(kml).toContain('151.2,-33.8,0');
+    });
+
+    it('escapes XML special characters', () => {
+      const kml = routesToKML([makeRoute({ name: 'Route <b> & "friends"' })]);
+      expect(kml).toContain('Route &lt;b&gt; &amp; &quot;friends&quot;');
+      expect(kml).not.toContain('<b> &');
+    });
+
+    it('omits the path placemark when there is no geometry', () => {
+      const kml = routesToKML([makeRoute({ geometry: undefined })]);
+      expect(kml).not.toContain('<LineString>');
+    });
+  });
+});

--- a/src/utils/__tests__/routeExport.test.ts
+++ b/src/utils/__tests__/routeExport.test.ts
@@ -8,6 +8,7 @@ import {
   routesToCSV,
   routesToKML,
   safeFilename,
+  buildPrintableRouteSummary,
   BACKUP_FORMAT,
 } from '../routeExport';
 import type { Route } from '../../types';
@@ -94,6 +95,48 @@ describe('routeExport', () => {
     it('omits the path placemark when there is no geometry', () => {
       const kml = routesToKML([makeRoute({ geometry: undefined })]);
       expect(kml).not.toContain('<LineString>');
+    });
+  });
+
+  describe('buildPrintableRouteSummary', () => {
+    it('escapes route and waypoint text', () => {
+      const html = buildPrintableRouteSummary(
+        makeRoute({ name: '<script>alert(1)</script>', description: '<img onerror=x>' })
+      );
+      expect(html).not.toContain('<script>alert(1)</script>');
+      expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+      expect(html).not.toContain('<img onerror=x>');
+    });
+
+    it('rejects a non-hex theme colour and falls back to the default', () => {
+      const html = buildPrintableRouteSummary(makeRoute(), {
+        name: 'B',
+        themeColor: 'red; } body { background: url(javascript:1) ',
+      });
+      expect(html).not.toContain('javascript:1');
+      expect(html).toContain('#D32F2F');
+    });
+
+    it('only accepts data-image or http(s) logo URLs', () => {
+      const bad = buildPrintableRouteSummary(makeRoute(), {
+        name: 'B',
+        logo: 'javascript:alert(1)',
+      });
+      expect(bad).not.toContain('javascript:alert(1)');
+
+      const good = buildPrintableRouteSummary(makeRoute(), {
+        name: 'B',
+        logo: 'data:image/png;base64,AAAA',
+      });
+      expect(good).toContain('data:image/png;base64,AAAA');
+    });
+
+    it('escapes quotes in the logo attribute', () => {
+      const html = buildPrintableRouteSummary(makeRoute(), {
+        name: 'B',
+        logo: 'https://example.com/logo.png" onerror="alert(1)',
+      });
+      expect(html).not.toContain('" onerror="');
     });
   });
 });

--- a/src/utils/__tests__/routeImport.test.ts
+++ b/src/utils/__tests__/routeImport.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Unit tests for route import utilities
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseImportFile,
+  parseGPX,
+  parseKML,
+  validateImportedRoute,
+  markDuplicates,
+  resolveCandidate,
+} from '../routeImport';
+import { routesToBackupJSON, routesToKML } from '../routeExport';
+import type { Route } from '../../types';
+
+function makeRoute(overrides: Partial<Route> = {}): Route {
+  return {
+    id: 'route-1',
+    brigadeId: 'brigade-1',
+    name: 'Test Route',
+    date: '2026-12-24',
+    startTime: '18:00',
+    status: 'published',
+    waypoints: [
+      { id: 'wp-1', coordinates: [151.2, -33.8], name: 'Start', order: 0, isCompleted: false },
+    ],
+    createdAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+const GPX_SAMPLE = `<?xml version="1.0"?>
+<gpx version="1.1" creator="test">
+  <metadata><name>Christmas Track</name></metadata>
+  <wpt lat="-33.8" lon="151.2"><name>Stop A</name><desc>Lollies here</desc></wpt>
+  <wpt lat="-33.9" lon="151.3"><name>Stop B</name></wpt>
+  <trk><trkseg>
+    <trkpt lat="-33.8" lon="151.2"/>
+    <trkpt lat="-33.85" lon="151.25"/>
+    <trkpt lat="-33.9" lon="151.3"/>
+  </trkseg></trk>
+</gpx>`;
+
+describe('routeImport', () => {
+  describe('JSON backup round-trip', () => {
+    it('re-imports a backup produced by routesToBackupJSON', () => {
+      const original = makeRoute();
+      const backup = routesToBackupJSON([original], { id: 'brigade-1', name: 'Griffith' });
+      const result = parseImportFile('backup.json', backup);
+      expect(result.source).toBe('backup');
+      expect(result.errors).toHaveLength(0);
+      expect(result.candidates).toHaveLength(1);
+      expect(result.candidates[0].route.name).toBe('Test Route');
+      expect(result.candidates[0].route.waypoints).toHaveLength(1);
+    });
+
+    it('accepts a bare single-route JSON export', () => {
+      const result = parseImportFile('route.json', JSON.stringify(makeRoute()));
+      expect(result.candidates).toHaveLength(1);
+    });
+
+    it('rejects invalid JSON', () => {
+      const result = parseImportFile('bad.json', '{oops');
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.candidates).toHaveLength(0);
+    });
+
+    it('rejects unrelated JSON', () => {
+      const result = parseImportFile('other.json', '{"hello": "world"}');
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('validateImportedRoute', () => {
+    it('skips waypoints with out-of-range coordinates', () => {
+      const { route, issues } = validateImportedRoute({
+        name: 'R',
+        waypoints: [
+          { coordinates: [151.2, -33.8] },
+          { coordinates: [999, -33.8] },
+        ],
+      });
+      expect(route?.waypoints).toHaveLength(1);
+      expect(issues.some(i => i.message.includes('invalid coordinates'))).toBe(true);
+    });
+
+    it('resets unknown status to draft with a warning', () => {
+      const { route, issues } = validateImportedRoute({ name: 'R', status: 'bogus', waypoints: [] });
+      expect(route?.status).toBe('draft');
+      expect(issues.some(i => i.message.includes('bogus'))).toBe(true);
+    });
+
+    it('fails without a name', () => {
+      const { route } = validateImportedRoute({ waypoints: [] });
+      expect(route).toBeNull();
+    });
+  });
+
+  describe('parseGPX', () => {
+    it('imports waypoints and track geometry', () => {
+      const result = parseGPX(GPX_SAMPLE, 'fallback');
+      expect(result.errors).toHaveLength(0);
+      const route = result.candidates[0].route;
+      expect(route.name).toBe('Christmas Track');
+      expect(route.waypoints).toHaveLength(2);
+      expect(route.waypoints[0].coordinates).toEqual([151.2, -33.8]);
+      expect(route.waypoints[0].notes).toBe('Lollies here');
+      expect(route.geometry?.coordinates).toHaveLength(3);
+      expect(route.status).toBe('draft');
+    });
+
+    it('creates Start/Finish stops from a track-only GPX', () => {
+      const trackOnly = GPX_SAMPLE.replace(/<wpt[\s\S]*?<\/wpt>/g, '');
+      const result = parseGPX(trackOnly, 'fallback');
+      const route = result.candidates[0].route;
+      expect(route.waypoints.map(w => w.name)).toEqual(['Start', 'Finish']);
+    });
+
+    it('rejects non-GPX content', () => {
+      const result = parseGPX('<html></html>', 'x');
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('parseKML round-trip', () => {
+    it('re-imports KML produced by routesToKML', () => {
+      const original = makeRoute({
+        waypoints: [
+          { id: 'wp-1', coordinates: [151.2, -33.8], name: 'Stop A', order: 0, isCompleted: false },
+          { id: 'wp-2', coordinates: [151.3, -33.9], name: 'Stop B', order: 1, isCompleted: false },
+        ],
+        geometry: { type: 'LineString', coordinates: [[151.2, -33.8], [151.3, -33.9]] },
+      });
+      const kml = routesToKML([original]);
+      const result = parseKML(kml, 'fallback');
+      expect(result.errors).toHaveLength(0);
+      const route = result.candidates[0].route;
+      expect(route.waypoints).toHaveLength(2);
+      expect(route.waypoints[0].name).toBe('Stop A');
+      expect(route.geometry?.coordinates).toHaveLength(2);
+    });
+  });
+
+  describe('duplicate handling', () => {
+    it('flags duplicates by id and by name+date', () => {
+      const existing = [makeRoute()];
+      const byId = parseImportFile('r.json', JSON.stringify(makeRoute({ name: 'Renamed' })));
+      const byNameDate = parseImportFile('r.json', JSON.stringify(makeRoute({ id: 'other-id' })));
+      expect(markDuplicates(byId.candidates, existing)[0].duplicateOf).toBe('route-1');
+      expect(markDuplicates(byNameDate.candidates, existing)[0].duplicateOf).toBe('route-1');
+    });
+
+    it('resolveCandidate honours skip/replace/copy and re-scopes brigade', () => {
+      const candidate = markDuplicates(
+        parseImportFile('r.json', JSON.stringify(makeRoute())).candidates,
+        [makeRoute()]
+      )[0];
+
+      expect(resolveCandidate({ ...candidate, resolution: 'skip' }, 'b-2')).toBeNull();
+
+      const replaced = resolveCandidate({ ...candidate, resolution: 'replace' }, 'b-2');
+      expect(replaced?.id).toBe('route-1');
+      expect(replaced?.brigadeId).toBe('b-2');
+
+      const copied = resolveCandidate({ ...candidate, resolution: 'copy' }, 'b-2');
+      expect(copied?.id).not.toBe('route-1');
+      expect(copied?.name).toContain('(imported)');
+    });
+  });
+});

--- a/src/utils/auditLog.ts
+++ b/src/utils/auditLog.ts
@@ -145,18 +145,20 @@ export function logAuditEvent(
  */
 let auditLogQueue: AuditLogEntry[] = [];
 
+/** Pending scheduled flush, so each queued entry doesn't stack another timer. */
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
 /**
  * Queue an audit log for batch sending.
  */
 function queueAuditLog(entry: AuditLogEntry): void {
   auditLogQueue.push(entry);
-  
+
   // Send batch every 10 logs or after 30 seconds
   if (auditLogQueue.length >= 10) {
     flushAuditLogs();
-  } else {
-    // Schedule flush after 30 seconds
-    setTimeout(flushAuditLogs, 30000);
+  } else if (flushTimer === null) {
+    flushTimer = setTimeout(flushAuditLogs, 30000);
   }
 }
 
@@ -164,11 +166,15 @@ function queueAuditLog(entry: AuditLogEntry): void {
  * Flush queued audit logs to the server.
  */
 async function flushAuditLogs(): Promise<void> {
+  if (flushTimer !== null) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
   if (auditLogQueue.length === 0) return;
-  
+
   const logs = [...auditLogQueue];
   auditLogQueue = [];
-  
+
   try {
     // Send to API endpoint
     await fetch('/api/audit/batch', {
@@ -185,6 +191,43 @@ async function flushAuditLogs(): Promise<void> {
       auditLogQueue.unshift(...logs);
     }
   }
+}
+
+/**
+ * Flush synchronously on page teardown via sendBeacon, so events queued just
+ * before the user closes the tab or navigates away (logout, role changes, …)
+ * aren't lost — fetch() doesn't survive page unload, sendBeacon does.
+ */
+function flushAuditLogsOnTeardown(): void {
+  if (auditLogQueue.length === 0) return;
+  const logs = [...auditLogQueue];
+
+  if (typeof navigator.sendBeacon === 'function') {
+    const payload = new Blob([JSON.stringify({ logs })], { type: 'application/json' });
+    if (navigator.sendBeacon('/api/audit/batch', payload)) {
+      auditLogQueue = [];
+      if (flushTimer !== null) {
+        clearTimeout(flushTimer);
+        flushTimer = null;
+      }
+    }
+  }
+}
+
+// Register teardown flushing once (browser production only — matches the
+// queueing condition in logAuditEvent). pagehide covers close/navigate;
+// visibilitychange covers mobile tab-switch, where pagehide may never fire.
+if (
+  typeof window !== 'undefined' &&
+  import.meta.env.PROD &&
+  import.meta.env.VITE_DEV_MODE !== 'true'
+) {
+  window.addEventListener('pagehide', flushAuditLogsOnTeardown);
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') {
+      flushAuditLogsOnTeardown();
+    }
+  });
 }
 
 /**

--- a/src/utils/etaPrediction.ts
+++ b/src/utils/etaPrediction.ts
@@ -1,0 +1,159 @@
+/**
+ * Predictive ETA — learns from historical route timing to adjust estimates.
+ *
+ * Completed routes already carry the ground truth (estimatedDuration vs
+ * actualDuration, waypoint estimated vs actual arrivals), so the "model" is a
+ * simple ratio estimator built from a brigade's completed routes:
+ *
+ *   predicted = baseEstimate × blend(overallFactor, timeOfDayFactor)
+ *
+ * Confidence is derived from sample count and the spread of observed factors.
+ * No external ML dependency — deliberately transparent and unit-testable.
+ */
+
+import type { Route } from '../types';
+
+export type EtaConfidence = 'low' | 'medium' | 'high';
+
+export interface EtaSample {
+  /** actualDuration / estimatedDuration for one completed route */
+  factor: number;
+  /** Hour of day (0-23) the route started, for time-of-day bucketing */
+  startHour: number | null;
+  routeId: string;
+  date: string;
+}
+
+export interface EtaModel {
+  samples: EtaSample[];
+  /** Median correction factor across all samples (1 = estimates are accurate) */
+  overallFactor: number;
+  /** Median factor per start-hour bucket (only buckets with >= 2 samples) */
+  hourFactors: Record<number, number>;
+  /** Spread of factors (interquartile range) — wide spread lowers confidence */
+  spread: number;
+}
+
+export interface EtaPrediction {
+  /** Adjusted duration in seconds */
+  duration: number;
+  /** Correction factor applied to the base estimate */
+  factor: number;
+  confidence: EtaConfidence;
+  sampleCount: number;
+}
+
+/** Bounds to keep one weird route from poisoning the model. */
+const MIN_FACTOR = 0.25;
+const MAX_FACTOR = 4;
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function quantile(values: number[], q: number): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const pos = (sorted.length - 1) * q;
+  const base = Math.floor(pos);
+  const rest = pos - base;
+  return sorted[base + 1] !== undefined ? sorted[base] + rest * (sorted[base + 1] - sorted[base]) : sorted[base];
+}
+
+function startHourOf(route: Route): number | null {
+  if (route.startedAt) {
+    const d = new Date(route.startedAt);
+    if (!Number.isNaN(d.getTime())) return d.getHours();
+  }
+  const match = /^(\d{1,2}):/.exec(route.startTime || '');
+  if (match) {
+    const h = parseInt(match[1], 10);
+    if (h >= 0 && h <= 23) return h;
+  }
+  return null;
+}
+
+/** Extract a timing sample from a completed route, or null if unusable. */
+export function sampleFromRoute(route: Route): EtaSample | null {
+  if (route.status !== 'completed' && route.status !== 'archived') return null;
+  if (!route.estimatedDuration || !route.actualDuration) return null;
+  if (route.estimatedDuration <= 0 || route.actualDuration <= 0) return null;
+  const factor = route.actualDuration / route.estimatedDuration;
+  if (factor < MIN_FACTOR || factor > MAX_FACTOR) return null; // outlier — likely paused/abandoned run
+  return { factor, startHour: startHourOf(route), routeId: route.id, date: route.date };
+}
+
+/** Build the brigade's ETA model from its route history. */
+export function buildEtaModel(routes: Route[]): EtaModel {
+  const samples = routes.map(sampleFromRoute).filter((s): s is EtaSample => s !== null);
+  if (samples.length === 0) {
+    return { samples: [], overallFactor: 1, hourFactors: {}, spread: 0 };
+  }
+
+  const factors = samples.map(s => s.factor);
+  const overallFactor = median(factors);
+  const spread = factors.length >= 4 ? quantile(factors, 0.75) - quantile(factors, 0.25) : 0;
+
+  const byHour = new Map<number, number[]>();
+  for (const s of samples) {
+    if (s.startHour === null) continue;
+    const list = byHour.get(s.startHour) ?? [];
+    list.push(s.factor);
+    byHour.set(s.startHour, list);
+  }
+  const hourFactors: Record<number, number> = {};
+  for (const [hour, list] of byHour) {
+    if (list.length >= 2) hourFactors[hour] = median(list);
+  }
+
+  return { samples, overallFactor, hourFactors, spread };
+}
+
+/**
+ * Predict an adjusted duration for a route given the brigade's model.
+ * `startHour` defaults to the route's own start hour when omitted.
+ */
+export function predictDuration(
+  baseEstimateSeconds: number,
+  model: EtaModel,
+  startHour?: number | null
+): EtaPrediction {
+  const n = model.samples.length;
+  if (n === 0 || baseEstimateSeconds <= 0) {
+    return { duration: baseEstimateSeconds, factor: 1, confidence: 'low', sampleCount: n };
+  }
+
+  // Blend the hour-specific factor with the overall factor when available
+  let factor = model.overallFactor;
+  if (startHour != null && model.hourFactors[startHour] !== undefined) {
+    factor = 0.5 * model.hourFactors[startHour] + 0.5 * model.overallFactor;
+  }
+
+  // Confidence: needs enough history and consistent behaviour
+  let confidence: EtaConfidence = 'low';
+  if (n >= 5 && model.spread < 0.25) confidence = 'high';
+  else if (n >= 3 && model.spread < 0.5) confidence = 'medium';
+
+  return {
+    duration: Math.round(baseEstimateSeconds * factor),
+    factor,
+    confidence,
+    sampleCount: n,
+  };
+}
+
+/** Convenience: predict for a specific route using the brigade's history. */
+export function predictRouteDuration(route: Route, allRoutes: Route[]): EtaPrediction | null {
+  if (!route.estimatedDuration) return null;
+  // Exclude the route itself so its own actuals don't self-confirm
+  const model = buildEtaModel(allRoutes.filter(r => r.id !== route.id));
+  if (model.samples.length === 0) return null;
+  return predictDuration(route.estimatedDuration, model, startHourOf(route));
+}
+
+export const CONFIDENCE_LABELS: Record<EtaConfidence, string> = {
+  low: 'Low confidence — little history yet',
+  medium: 'Medium confidence — based on a few past runs',
+  high: 'High confidence — consistent past run timing',
+};

--- a/src/utils/routeExport.ts
+++ b/src/utils/routeExport.ts
@@ -1,0 +1,306 @@
+/**
+ * Route export utilities — JSON, CSV, KML and print-friendly summaries.
+ *
+ * All exporters are pure string generators so they can be unit-tested;
+ * `downloadFile` handles the browser download plumbing.
+ */
+
+import type { Route, Waypoint } from '../types';
+import type { Brigade } from '../storage/types';
+import { MAPBOX_TOKEN, EXAMPLE_MAPBOX_TOKEN } from '../config/mapbox';
+
+/** Versioned envelope for JSON backups so imports can validate provenance. */
+export interface RouteBackup {
+  format: 'fire-santa-run-backup';
+  version: 1;
+  exportedAt: string;
+  brigadeId?: string;
+  brigadeName?: string;
+  routes: Route[];
+}
+
+export const BACKUP_FORMAT = 'fire-santa-run-backup';
+export const BACKUP_VERSION = 1;
+
+/** Make a string safe for use in a downloaded filename. */
+export function safeFilename(name: string): string {
+  return name.replace(/[^a-z0-9-_ ]/gi, '').trim().replace(/\s+/g, '-').toLowerCase() || 'route';
+}
+
+/** Serialise one or more routes into the versioned backup envelope. */
+export function routesToBackupJSON(routes: Route[], brigade?: Pick<Brigade, 'id' | 'name'> | null): string {
+  const backup: RouteBackup = {
+    format: BACKUP_FORMAT,
+    version: BACKUP_VERSION,
+    exportedAt: new Date().toISOString(),
+    brigadeId: brigade?.id ?? routes[0]?.brigadeId,
+    brigadeName: brigade?.name,
+    routes,
+  };
+  return JSON.stringify(backup, null, 2);
+}
+
+/** Escape a value for a CSV cell (RFC 4180). */
+function csvCell(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  if (/[",\n\r]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+const CSV_HEADER = [
+  'route_id', 'route_name', 'route_date', 'route_status', 'route_distance_m',
+  'route_estimated_duration_s', 'route_actual_duration_s', 'route_view_count',
+  'waypoint_order', 'waypoint_name', 'waypoint_address',
+  'longitude', 'latitude', 'estimated_arrival', 'actual_arrival', 'completed', 'notes',
+].join(',');
+
+/** One CSV row per waypoint, with route metadata repeated on each row. */
+export function routesToCSV(routes: Route[]): string {
+  const rows: string[] = [CSV_HEADER];
+  for (const route of routes) {
+    const waypoints = [...route.waypoints].sort((a, b) => a.order - b.order);
+    if (waypoints.length === 0) {
+      rows.push([
+        route.id, route.name, route.date, route.status, route.distance ?? '',
+        route.estimatedDuration ?? '', route.actualDuration ?? '', route.viewCount ?? '',
+        '', '', '', '', '', '', '', '', '',
+      ].map(csvCell).join(','));
+      continue;
+    }
+    for (const wp of waypoints) {
+      rows.push([
+        route.id, route.name, route.date, route.status, route.distance ?? '',
+        route.estimatedDuration ?? '', route.actualDuration ?? '', route.viewCount ?? '',
+        wp.order, wp.name ?? '', wp.address ?? '',
+        wp.coordinates[0], wp.coordinates[1],
+        wp.estimatedArrival ?? '', wp.actualArrival ?? '',
+        wp.isCompleted ? 'yes' : 'no', wp.notes ?? '',
+      ].map(csvCell).join(','));
+    }
+  }
+  return rows.join('\r\n');
+}
+
+/** Escape XML special characters. */
+function xmlEscape(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function waypointPlacemark(wp: Waypoint, index: number): string {
+  const name = xmlEscape(wp.name || `Stop ${index + 1}`);
+  const descriptionParts = [wp.address, wp.notes].filter(Boolean).map(s => xmlEscape(s!));
+  const description = descriptionParts.length
+    ? `\n      <description>${descriptionParts.join(' — ')}</description>`
+    : '';
+  return `    <Placemark>
+      <name>${name}</name>${description}
+      <Point>
+        <coordinates>${wp.coordinates[0]},${wp.coordinates[1]},0</coordinates>
+      </Point>
+    </Placemark>`;
+}
+
+/** Export routes as KML (Google Earth). Waypoints become Placemarks; geometry becomes a LineString path. */
+export function routesToKML(routes: Route[], documentName = 'Fire Santa Run Export'): string {
+  const folders = routes.map(route => {
+    const waypoints = [...route.waypoints].sort((a, b) => a.order - b.order);
+    const placemarks = waypoints.map((wp, i) => waypointPlacemark(wp, i)).join('\n');
+    const path = route.geometry && route.geometry.coordinates.length > 1
+      ? `    <Placemark>
+      <name>${xmlEscape(route.name)} — path</name>
+      <styleUrl>#routeLine</styleUrl>
+      <LineString>
+        <tessellate>1</tessellate>
+        <coordinates>${route.geometry.coordinates.map(([lng, lat]) => `${lng},${lat},0`).join(' ')}</coordinates>
+      </LineString>
+    </Placemark>`
+      : '';
+    return `  <Folder>
+    <name>${xmlEscape(route.name)}</name>
+    <description>${xmlEscape(route.description || '')} (${xmlEscape(route.date)})</description>
+${[placemarks, path].filter(Boolean).join('\n')}
+  </Folder>`;
+  }).join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+<Document>
+  <name>${xmlEscape(documentName)}</name>
+  <Style id="routeLine">
+    <LineStyle>
+      <color>ff2f2fd3</color>
+      <width>4</width>
+    </LineStyle>
+  </Style>
+${folders}
+</Document>
+</kml>`;
+}
+
+/** Trigger a browser download of generated content. */
+export function downloadFile(filename: string, content: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+/** Build a Mapbox Static Images URL for a route overview (or null if no token/geometry). */
+export function buildStaticMapUrl(route: Route, width = 640, height = 360): string | null {
+  if (!MAPBOX_TOKEN || MAPBOX_TOKEN === EXAMPLE_MAPBOX_TOKEN) return null;
+  const coords = route.geometry?.coordinates?.length
+    ? route.geometry.coordinates
+    : route.waypoints.map(wp => wp.coordinates);
+  if (coords.length === 0) return null;
+
+  // Pin markers for up to the first 10 waypoints (static API URL length limits)
+  const pins = route.waypoints
+    .slice()
+    .sort((a, b) => a.order - b.order)
+    .slice(0, 10)
+    .map((wp, i) => `pin-s-${(i + 1) % 10}+d32f2f(${wp.coordinates[0]},${wp.coordinates[1]})`);
+
+  // Encode the route path as a GeoJSON overlay when available (simplified to keep URL short)
+  const overlays: string[] = [...pins];
+  if (route.geometry && route.geometry.coordinates.length > 1) {
+    const step = Math.max(1, Math.floor(route.geometry.coordinates.length / 80));
+    const simplified = route.geometry.coordinates.filter((_, i, arr) => i % step === 0 || i === arr.length - 1);
+    const geojson = { type: 'Feature', properties: { stroke: '#D32F2F', 'stroke-width': 4 }, geometry: { type: 'LineString', coordinates: simplified } };
+    overlays.push(`geojson(${encodeURIComponent(JSON.stringify(geojson))})`);
+  }
+
+  return `https://api.mapbox.com/styles/v1/mapbox/streets-v12/static/${overlays.join(',')}/auto/${width}x${height}@2x?padding=40&access_token=${MAPBOX_TOKEN}`;
+}
+
+function formatDurationHuman(seconds?: number): string {
+  if (!seconds) return '—';
+  const h = Math.floor(seconds / 3600);
+  const m = Math.round((seconds % 3600) / 60);
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
+/**
+ * Build a print-friendly HTML route summary (map image, waypoint table,
+ * turn-by-turn instructions, brigade branding). Users print or "Save as PDF"
+ * from the browser dialog.
+ */
+export function buildPrintableRouteSummary(route: Route, brigade?: Pick<Brigade, 'name' | 'logo' | 'themeColor'> | null): string {
+  const themeColor = brigade?.themeColor || '#D32F2F';
+  const mapUrl = buildStaticMapUrl(route, 800, 400);
+  const waypoints = [...route.waypoints].sort((a, b) => a.order - b.order);
+
+  const waypointRows = waypoints.map((wp, i) => `
+      <tr>
+        <td class="num">${i + 1}</td>
+        <td>${xmlEscape(wp.name || `Stop ${i + 1}`)}</td>
+        <td>${xmlEscape(wp.address || '')}</td>
+        <td>${wp.estimatedArrival ? xmlEscape(new Date(wp.estimatedArrival).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })) : '—'}</td>
+        <td>${xmlEscape(wp.notes || '')}</td>
+      </tr>`).join('');
+
+  const instructions = (route.navigationSteps || []).map((step, i) => `
+      <li><span class="step-num">${i + 1}.</span> ${xmlEscape(step.instruction)} <span class="muted">(${(step.distance / 1000).toFixed(1)} km)</span></li>`).join('');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${xmlEscape(route.name)} — Route Summary</title>
+<style>
+  body { font-family: 'Segoe UI', system-ui, sans-serif; color: #212121; margin: 2rem; }
+  header { display: flex; align-items: center; gap: 1rem; border-bottom: 4px solid ${themeColor}; padding-bottom: 1rem; margin-bottom: 1.5rem; }
+  header img { height: 56px; width: 56px; object-fit: contain; border-radius: 8px; }
+  h1 { margin: 0; font-size: 1.6rem; color: ${themeColor}; }
+  .subtitle { color: #616161; margin: 0.25rem 0 0; }
+  .meta { display: flex; gap: 2rem; flex-wrap: wrap; margin-bottom: 1.5rem; }
+  .meta div { font-size: 0.95rem; }
+  .meta strong { display: block; color: ${themeColor}; font-size: 1.15rem; }
+  .map { width: 100%; max-width: 800px; border-radius: 8px; margin-bottom: 1.5rem; }
+  table { border-collapse: collapse; width: 100%; margin-bottom: 1.5rem; font-size: 0.85rem; }
+  th, td { border: 1px solid #E0E0E0; padding: 0.4rem 0.6rem; text-align: left; vertical-align: top; }
+  th { background: ${themeColor}; color: white; }
+  td.num { text-align: center; font-weight: 700; }
+  ol { padding-left: 1.25rem; font-size: 0.85rem; }
+  ol li { margin-bottom: 0.25rem; }
+  .muted { color: #757575; }
+  h2 { font-size: 1.1rem; border-bottom: 2px solid #E0E0E0; padding-bottom: 0.25rem; }
+  footer { margin-top: 2rem; font-size: 0.75rem; color: #757575; border-top: 1px solid #E0E0E0; padding-top: 0.5rem; }
+  @media print { body { margin: 0.5cm; } .no-print { display: none; } }
+</style>
+</head>
+<body>
+  <header>
+    ${brigade?.logo ? `<img src="${brigade.logo}" alt="">` : ''}
+    <div>
+      <h1>🎅 ${xmlEscape(route.name)}</h1>
+      <p class="subtitle">${brigade?.name ? xmlEscape(brigade.name) + ' · ' : ''}${xmlEscape(new Date(route.date).toLocaleDateString([], { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' }))}${route.startTime ? ' · departs ' + xmlEscape(route.startTime) : ''}</p>
+    </div>
+  </header>
+  ${route.description ? `<p>${xmlEscape(route.description)}</p>` : ''}
+  <div class="meta">
+    <div><strong>${waypoints.length}</strong> Stops</div>
+    <div><strong>${route.distance ? (route.distance / 1000).toFixed(1) + ' km' : '—'}</strong> Distance</div>
+    <div><strong>${formatDurationHuman(route.estimatedDuration)}</strong> Est. duration</div>
+    <div><strong>${xmlEscape(route.status)}</strong> Status</div>
+  </div>
+  ${mapUrl ? `<img class="map" src="${mapUrl}" alt="Route overview map">` : ''}
+  <h2>📍 Stops</h2>
+  <table>
+    <thead><tr><th>#</th><th>Name</th><th>Address</th><th>ETA</th><th>Notes</th></tr></thead>
+    <tbody>${waypointRows}</tbody>
+  </table>
+  ${instructions ? `<h2>🧭 Turn-by-turn instructions</h2>\n  <ol>${instructions}</ol>` : ''}
+  <footer>Generated by Fire Santa Run on ${xmlEscape(new Date().toLocaleString())}</footer>
+  <script>window.addEventListener('load', function () { setTimeout(function () { window.print(); }, 300); });</script>
+</body>
+</html>`;
+}
+
+/** Open the printable summary in a new window and trigger the print dialog. */
+export function openPrintableRouteSummary(route: Route, brigade?: Pick<Brigade, 'name' | 'logo' | 'themeColor'> | null): void {
+  const html = buildPrintableRouteSummary(route, brigade);
+  const win = window.open('', '_blank', 'noopener');
+  if (!win) {
+    alert('Please allow pop-ups to print the route summary.');
+    return;
+  }
+  win.document.write(html);
+  win.document.close();
+}
+
+/** Export a single route in the chosen format and download it. */
+export function exportRoute(route: Route, format: 'json' | 'csv' | 'kml', brigade?: Pick<Brigade, 'id' | 'name'> | null): void {
+  const base = safeFilename(route.name);
+  if (format === 'json') {
+    downloadFile(`${base}.json`, routesToBackupJSON([route], brigade), 'application/json');
+  } else if (format === 'csv') {
+    downloadFile(`${base}.csv`, routesToCSV([route]), 'text/csv');
+  } else {
+    downloadFile(`${base}.kml`, routesToKML([route], route.name), 'application/vnd.google-earth.kml+xml');
+  }
+}
+
+/** Export all brigade routes in the chosen format and download it. */
+export function exportRoutes(routes: Route[], format: 'json' | 'csv' | 'kml', brigade?: Pick<Brigade, 'id' | 'name'> | null): void {
+  const base = safeFilename(brigade?.name ? `${brigade.name}-routes` : 'brigade-routes');
+  if (format === 'json') {
+    downloadFile(`${base}.json`, routesToBackupJSON(routes, brigade), 'application/json');
+  } else if (format === 'csv') {
+    downloadFile(`${base}.csv`, routesToCSV(routes), 'text/csv');
+  } else {
+    downloadFile(`${base}.kml`, routesToKML(routes, brigade?.name || 'Brigade routes'), 'application/vnd.google-earth.kml+xml');
+  }
+}

--- a/src/utils/routeExport.ts
+++ b/src/utils/routeExport.ts
@@ -198,7 +198,15 @@ function formatDurationHuman(seconds?: number): string {
  * from the browser dialog.
  */
 export function buildPrintableRouteSummary(route: Route, brigade?: Pick<Brigade, 'name' | 'logo' | 'themeColor'> | null): string {
-  const themeColor = brigade?.themeColor || '#D32F2F';
+  // Sanitise values interpolated outside xmlEscape'd text nodes:
+  // theme colour goes into CSS — only accept a hex colour literal
+  const themeColor = brigade?.themeColor && /^#[0-9a-fA-F]{3,8}$/.test(brigade.themeColor)
+    ? brigade.themeColor
+    : '#D32F2F';
+  // logo goes into an img src attribute — only accept data-URL images or http(s) URLs
+  const logoSrc = brigade?.logo && /^(data:image\/|https?:\/\/)/i.test(brigade.logo)
+    ? xmlEscape(brigade.logo)
+    : null;
   const mapUrl = buildStaticMapUrl(route, 800, 400);
   const waypoints = [...route.waypoints].sort((a, b) => a.order - b.order);
 
@@ -243,7 +251,7 @@ export function buildPrintableRouteSummary(route: Route, brigade?: Pick<Brigade,
 </head>
 <body>
   <header>
-    ${brigade?.logo ? `<img src="${brigade.logo}" alt="">` : ''}
+    ${logoSrc ? `<img src="${logoSrc}" alt="">` : ''}
     <div>
       <h1>🎅 ${xmlEscape(route.name)}</h1>
       <p class="subtitle">${brigade?.name ? xmlEscape(brigade.name) + ' · ' : ''}${xmlEscape(new Date(route.date).toLocaleDateString([], { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' }))}${route.startTime ? ' · departs ' + xmlEscape(route.startTime) : ''}</p>
@@ -256,7 +264,7 @@ export function buildPrintableRouteSummary(route: Route, brigade?: Pick<Brigade,
     <div><strong>${formatDurationHuman(route.estimatedDuration)}</strong> Est. duration</div>
     <div><strong>${xmlEscape(route.status)}</strong> Status</div>
   </div>
-  ${mapUrl ? `<img class="map" src="${mapUrl}" alt="Route overview map">` : ''}
+  ${mapUrl ? `<img class="map" src="${xmlEscape(mapUrl)}" alt="Route overview map">` : ''}
   <h2>📍 Stops</h2>
   <table>
     <thead><tr><th>#</th><th>Name</th><th>Address</th><th>ETA</th><th>Notes</th></tr></thead>
@@ -272,13 +280,19 @@ export function buildPrintableRouteSummary(route: Route, brigade?: Pick<Brigade,
 /** Open the printable summary in a new window and trigger the print dialog. */
 export function openPrintableRouteSummary(route: Route, brigade?: Pick<Brigade, 'name' | 'logo' | 'themeColor'> | null): void {
   const html = buildPrintableRouteSummary(route, brigade);
-  const win = window.open('', '_blank', 'noopener');
+  // Load via a Blob URL rather than document.write: all interpolated values in
+  // the generated document are escaped/validated, and the blob document gets a
+  // unique opaque origin instead of inheriting the app's origin.
+  const blob = new Blob([html], { type: 'text/html' });
+  const url = URL.createObjectURL(blob);
+  const win = window.open(url, '_blank', 'noopener');
   if (!win) {
+    URL.revokeObjectURL(url);
     alert('Please allow pop-ups to print the route summary.');
     return;
   }
-  win.document.write(html);
-  win.document.close();
+  // Revoke once the new window has had time to load the blob
+  setTimeout(() => URL.revokeObjectURL(url), 60_000);
 }
 
 /** Export a single route in the chosen format and download it. */

--- a/src/utils/routeImport.ts
+++ b/src/utils/routeImport.ts
@@ -1,0 +1,363 @@
+/**
+ * Route import utilities — JSON backups (restore), GPX and KML files.
+ *
+ * Parsing and validation are pure functions returning an ImportResult that the
+ * UI renders as a preview before anything is written to storage.
+ */
+
+import type { Route, Waypoint, GeoJSON } from '../types';
+import { BACKUP_FORMAT } from './routeExport';
+
+export interface ImportIssue {
+  severity: 'error' | 'warning';
+  message: string;
+}
+
+/** A parsed candidate route plus validation/duplicate state for the preview UI. */
+export interface ImportCandidate {
+  route: Route;
+  issues: ImportIssue[];
+  /** ID of an existing route this candidate duplicates (same id, or same name+date) */
+  duplicateOf?: string;
+  /** How the user chose to resolve a duplicate */
+  resolution: 'import' | 'replace' | 'copy' | 'skip';
+}
+
+export interface ImportResult {
+  source: 'backup' | 'route-json' | 'gpx' | 'kml';
+  candidates: ImportCandidate[];
+  errors: string[];
+}
+
+function makeId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+function isFiniteNumber(n: unknown): n is number {
+  return typeof n === 'number' && Number.isFinite(n);
+}
+
+function isValidCoordinate(c: unknown): c is [number, number] {
+  return Array.isArray(c) && c.length === 2 && isFiniteNumber(c[0]) && isFiniteNumber(c[1])
+    && c[0] >= -180 && c[0] <= 180 && c[1] >= -90 && c[1] <= 90;
+}
+
+/** Validate a route-shaped object; returns issues and a sanitised Route (or null if unusable). */
+export function validateImportedRoute(raw: unknown): { route: Route | null; issues: ImportIssue[] } {
+  const issues: ImportIssue[] = [];
+  if (typeof raw !== 'object' || raw === null) {
+    return { route: null, issues: [{ severity: 'error', message: 'Route entry is not an object' }] };
+  }
+  const obj = raw as Record<string, unknown>;
+
+  if (typeof obj.name !== 'string' || !obj.name.trim()) {
+    issues.push({ severity: 'error', message: 'Route is missing a name' });
+    return { route: null, issues };
+  }
+
+  const waypointsRaw = Array.isArray(obj.waypoints) ? obj.waypoints : [];
+  const waypoints: Waypoint[] = [];
+  waypointsRaw.forEach((wpRaw, i) => {
+    if (typeof wpRaw !== 'object' || wpRaw === null) {
+      issues.push({ severity: 'warning', message: `Waypoint ${i + 1} skipped: not an object` });
+      return;
+    }
+    const wp = wpRaw as Record<string, unknown>;
+    if (!isValidCoordinate(wp.coordinates)) {
+      issues.push({ severity: 'warning', message: `Waypoint ${i + 1} skipped: invalid coordinates` });
+      return;
+    }
+    waypoints.push({
+      id: typeof wp.id === 'string' ? wp.id : makeId('wp'),
+      coordinates: wp.coordinates as [number, number],
+      address: typeof wp.address === 'string' ? wp.address : undefined,
+      name: typeof wp.name === 'string' ? wp.name : undefined,
+      order: isFiniteNumber(wp.order) ? wp.order : i,
+      notes: typeof wp.notes === 'string' ? wp.notes : undefined,
+      estimatedArrival: typeof wp.estimatedArrival === 'string' ? wp.estimatedArrival : undefined,
+      actualArrival: typeof wp.actualArrival === 'string' ? wp.actualArrival : undefined,
+      isCompleted: wp.isCompleted === true,
+    });
+  });
+
+  if (waypoints.length === 0) {
+    issues.push({ severity: 'warning', message: 'Route has no valid waypoints' });
+  }
+
+  let geometry: GeoJSON.LineString | undefined;
+  const geomRaw = obj.geometry as Record<string, unknown> | undefined;
+  if (geomRaw && geomRaw.type === 'LineString' && Array.isArray(geomRaw.coordinates)) {
+    const coords = (geomRaw.coordinates as unknown[]).filter(isValidCoordinate) as [number, number][];
+    if (coords.length >= 2) {
+      geometry = { type: 'LineString', coordinates: coords };
+    } else {
+      issues.push({ severity: 'warning', message: 'Route geometry dropped: fewer than 2 valid points' });
+    }
+  }
+
+  const validStatuses = ['draft', 'published', 'active', 'completed', 'archived'];
+  const status = typeof obj.status === 'string' && validStatuses.includes(obj.status) ? obj.status : 'draft';
+  if (obj.status && status !== obj.status) {
+    issues.push({ severity: 'warning', message: `Unknown status "${String(obj.status)}" reset to draft` });
+  }
+
+  const route: Route = {
+    id: typeof obj.id === 'string' ? obj.id : makeId('route'),
+    brigadeId: typeof obj.brigadeId === 'string' ? obj.brigadeId : '',
+    name: obj.name.trim(),
+    description: typeof obj.description === 'string' ? obj.description : undefined,
+    date: typeof obj.date === 'string' && !Number.isNaN(Date.parse(obj.date)) ? obj.date : new Date().toISOString().slice(0, 10),
+    startTime: typeof obj.startTime === 'string' ? obj.startTime : '18:00',
+    endTime: typeof obj.endTime === 'string' ? obj.endTime : undefined,
+    status: status as Route['status'],
+    waypoints,
+    geometry,
+    navigationSteps: Array.isArray(obj.navigationSteps) ? (obj.navigationSteps as Route['navigationSteps']) : undefined,
+    distance: isFiniteNumber(obj.distance) ? obj.distance : undefined,
+    estimatedDuration: isFiniteNumber(obj.estimatedDuration) ? obj.estimatedDuration : undefined,
+    actualDuration: isFiniteNumber(obj.actualDuration) ? obj.actualDuration : undefined,
+    navigationSettings: typeof obj.navigationSettings === 'object' && obj.navigationSettings !== null
+      ? (obj.navigationSettings as Route['navigationSettings'])
+      : undefined,
+    createdAt: typeof obj.createdAt === 'string' ? obj.createdAt : new Date().toISOString(),
+    comments: Array.isArray(obj.comments) ? (obj.comments as Route['comments']) : undefined,
+  };
+
+  if (typeof obj.date === 'string' && Number.isNaN(Date.parse(obj.date))) {
+    issues.push({ severity: 'warning', message: `Invalid date "${obj.date}" reset to today` });
+  }
+
+  return { route, issues };
+}
+
+function parseJSONImport(content: string): ImportResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return { source: 'route-json', candidates: [], errors: ['File is not valid JSON'] };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  let rawRoutes: unknown[];
+  let source: ImportResult['source'];
+
+  if (obj && obj.format === BACKUP_FORMAT && Array.isArray(obj.routes)) {
+    rawRoutes = obj.routes;
+    source = 'backup';
+  } else if (Array.isArray(parsed)) {
+    rawRoutes = parsed;
+    source = 'route-json';
+  } else if (obj && (Array.isArray(obj.waypoints) || typeof obj.name === 'string')) {
+    rawRoutes = [parsed];
+    source = 'route-json';
+  } else {
+    return {
+      source: 'route-json',
+      candidates: [],
+      errors: ['JSON does not look like a Fire Santa Run backup or route export'],
+    };
+  }
+
+  const errors: string[] = [];
+  const candidates: ImportCandidate[] = [];
+  rawRoutes.forEach((raw, i) => {
+    const { route, issues } = validateImportedRoute(raw);
+    if (!route) {
+      errors.push(`Entry ${i + 1}: ${issues.map(iss => iss.message).join('; ')}`);
+      return;
+    }
+    candidates.push({ route, issues, resolution: 'import' });
+  });
+
+  return { source, candidates, errors };
+}
+
+function parseXml(content: string): Document | null {
+  const doc = new DOMParser().parseFromString(content, 'application/xml');
+  return doc.querySelector('parsererror') ? null : doc;
+}
+
+/** Parse a GPX file: <wpt> elements become waypoints, first <trk>/<rte> becomes geometry. */
+export function parseGPX(content: string, fallbackName: string): ImportResult {
+  const doc = parseXml(content);
+  if (!doc || !doc.querySelector('gpx')) {
+    return { source: 'gpx', candidates: [], errors: ['File is not a valid GPX document'] };
+  }
+
+  const issues: ImportIssue[] = [];
+  const waypoints: Waypoint[] = [];
+  doc.querySelectorAll('wpt').forEach((el, i) => {
+    const lat = parseFloat(el.getAttribute('lat') || '');
+    const lon = parseFloat(el.getAttribute('lon') || '');
+    if (!isValidCoordinate([lon, lat])) {
+      issues.push({ severity: 'warning', message: `GPX waypoint ${i + 1} skipped: invalid lat/lon` });
+      return;
+    }
+    waypoints.push({
+      id: makeId('wp'),
+      coordinates: [lon, lat],
+      name: el.querySelector('name')?.textContent?.trim() || undefined,
+      notes: el.querySelector('desc')?.textContent?.trim() || undefined,
+      order: waypoints.length,
+      isCompleted: false,
+    });
+  });
+
+  const trackPoints: [number, number][] = [];
+  doc.querySelectorAll('trkpt, rtept').forEach(el => {
+    const lat = parseFloat(el.getAttribute('lat') || '');
+    const lon = parseFloat(el.getAttribute('lon') || '');
+    if (isValidCoordinate([lon, lat])) trackPoints.push([lon, lat]);
+  });
+
+  // A GPX with only a track still imports: track points become the geometry,
+  // and start/end become waypoints so the route is editable.
+  if (waypoints.length === 0 && trackPoints.length >= 2) {
+    waypoints.push(
+      { id: makeId('wp'), coordinates: trackPoints[0], name: 'Start', order: 0, isCompleted: false },
+      { id: makeId('wp'), coordinates: trackPoints[trackPoints.length - 1], name: 'Finish', order: 1, isCompleted: false },
+    );
+    issues.push({ severity: 'warning', message: 'No GPX waypoints found — created Start/Finish stops from the track' });
+  }
+
+  if (waypoints.length === 0) {
+    return { source: 'gpx', candidates: [], errors: ['GPX file contains no usable waypoints or track points'] };
+  }
+
+  const name = doc.querySelector('gpx > metadata > name, trk > name, rte > name')?.textContent?.trim() || fallbackName;
+  const route: Route = {
+    id: makeId('route'),
+    brigadeId: '',
+    name,
+    date: new Date().toISOString().slice(0, 10),
+    startTime: '18:00',
+    status: 'draft',
+    waypoints,
+    geometry: trackPoints.length >= 2 ? { type: 'LineString', coordinates: trackPoints } : undefined,
+    createdAt: new Date().toISOString(),
+  };
+
+  return { source: 'gpx', candidates: [{ route, issues, resolution: 'import' }], errors: [] };
+}
+
+/** Parse a KML file: Point Placemarks become waypoints, first LineString becomes geometry. */
+export function parseKML(content: string, fallbackName: string): ImportResult {
+  const doc = parseXml(content);
+  if (!doc || !doc.querySelector('kml')) {
+    return { source: 'kml', candidates: [], errors: ['File is not a valid KML document'] };
+  }
+
+  const issues: ImportIssue[] = [];
+  const waypoints: Waypoint[] = [];
+  let lineCoords: [number, number][] = [];
+
+  doc.querySelectorAll('Placemark').forEach((pm, i) => {
+    const name = pm.querySelector('name')?.textContent?.trim() || undefined;
+    const description = pm.querySelector('description')?.textContent?.trim() || undefined;
+    const pointCoords = pm.querySelector('Point > coordinates')?.textContent?.trim();
+    if (pointCoords) {
+      const [lon, lat] = pointCoords.split(',').map(parseFloat);
+      if (isValidCoordinate([lon, lat])) {
+        waypoints.push({
+          id: makeId('wp'),
+          coordinates: [lon, lat],
+          name,
+          notes: description,
+          order: waypoints.length,
+          isCompleted: false,
+        });
+      } else {
+        issues.push({ severity: 'warning', message: `Placemark ${i + 1} skipped: invalid coordinates` });
+      }
+      return;
+    }
+    const lineText = pm.querySelector('LineString > coordinates')?.textContent?.trim();
+    if (lineText && lineCoords.length === 0) {
+      lineCoords = lineText.split(/\s+/).map(triple => {
+        const [lon, lat] = triple.split(',').map(parseFloat);
+        return [lon, lat] as [number, number];
+      }).filter(isValidCoordinate);
+    }
+  });
+
+  if (waypoints.length === 0 && lineCoords.length >= 2) {
+    waypoints.push(
+      { id: makeId('wp'), coordinates: lineCoords[0], name: 'Start', order: 0, isCompleted: false },
+      { id: makeId('wp'), coordinates: lineCoords[lineCoords.length - 1], name: 'Finish', order: 1, isCompleted: false },
+    );
+    issues.push({ severity: 'warning', message: 'No point Placemarks found — created Start/Finish stops from the path' });
+  }
+
+  if (waypoints.length === 0) {
+    return { source: 'kml', candidates: [], errors: ['KML file contains no usable Placemarks'] };
+  }
+
+  const name = doc.querySelector('Document > name, Folder > name')?.textContent?.trim() || fallbackName;
+  const route: Route = {
+    id: makeId('route'),
+    brigadeId: '',
+    name,
+    date: new Date().toISOString().slice(0, 10),
+    startTime: '18:00',
+    status: 'draft',
+    waypoints,
+    geometry: lineCoords.length >= 2 ? { type: 'LineString', coordinates: lineCoords } : undefined,
+    createdAt: new Date().toISOString(),
+  };
+
+  return { source: 'kml', candidates: [{ route, issues, resolution: 'import' }], errors: [] };
+}
+
+/** Parse an uploaded file by extension/content into import candidates. */
+export function parseImportFile(filename: string, content: string): ImportResult {
+  const lower = filename.toLowerCase();
+  if (lower.endsWith('.gpx')) return parseGPX(content, filename.replace(/\.gpx$/i, ''));
+  if (lower.endsWith('.kml')) return parseKML(content, filename.replace(/\.kml$/i, ''));
+  if (lower.endsWith('.json')) return parseJSONImport(content);
+
+  // Sniff content for extensionless files
+  const trimmed = content.trimStart();
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) return parseJSONImport(content);
+  if (trimmed.includes('<gpx')) return parseGPX(content, filename);
+  if (trimmed.includes('<kml')) return parseKML(content, filename);
+  return { source: 'route-json', candidates: [], errors: ['Unsupported file type — use .json, .gpx or .kml'] };
+}
+
+/** Flag candidates that duplicate existing routes (same id, or same name + date). */
+export function markDuplicates(candidates: ImportCandidate[], existingRoutes: Route[]): ImportCandidate[] {
+  return candidates.map(candidate => {
+    const byId = existingRoutes.find(r => r.id === candidate.route.id);
+    const byNameDate = existingRoutes.find(
+      r => r.name.toLowerCase() === candidate.route.name.toLowerCase() && r.date === candidate.route.date
+    );
+    const duplicate = byId || byNameDate;
+    if (!duplicate) return candidate;
+    return {
+      ...candidate,
+      duplicateOf: duplicate.id,
+      resolution: 'copy',
+      issues: [
+        ...candidate.issues,
+        { severity: 'warning', message: `Matches existing route "${duplicate.name}" (${duplicate.date})` },
+      ],
+    };
+  });
+}
+
+/**
+ * Materialise a candidate into the route that should be saved, applying the
+ * chosen duplicate resolution and re-scoping to the target brigade.
+ * Returns null when the candidate is skipped.
+ */
+export function resolveCandidate(candidate: ImportCandidate, brigadeId: string): Route | null {
+  if (candidate.resolution === 'skip') return null;
+  const route: Route = { ...candidate.route, brigadeId };
+  if (candidate.resolution === 'replace' && candidate.duplicateOf) {
+    route.id = candidate.duplicateOf;
+  } else if (candidate.resolution === 'copy' && candidate.duplicateOf) {
+    route.id = makeId('route');
+    route.name = `${route.name} (imported)`;
+  }
+  return route;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,19 +44,30 @@ export default defineConfig(( env: ConfigEnv ): UserConfig => {
     build: {
       rollupOptions: {
         output: {
-          manualChunks: {
-            // Split React and React-DOM into separate chunk
-            'react-vendor': ['react', 'react-dom', 'react-router-dom'],
-            // Split Mapbox (large mapping library) into separate chunk
-            'mapbox': ['mapbox-gl', '@mapbox/mapbox-gl-geocoder', '@mapbox/mapbox-gl-draw'],
-            // Split Azure SDKs into separate chunk
-            'azure': ['@azure/msal-browser', '@azure/msal-react', '@azure/data-tables', '@azure/web-pubsub-client'],
-            // Split UI libraries into separate chunk
-            'ui-libs': ['@dnd-kit/core', '@dnd-kit/sortable', '@dnd-kit/utilities', 'qrcode.react'],
-            // Split Socket.IO into separate chunk
-            'realtime': ['socket.io-client'],
-            // Split date utilities
-            'date-utils': ['date-fns'],
+          // Vite 8 (Rolldown) only accepts the function form of manualChunks;
+          // the object form fails type-checking and the build.
+          manualChunks: (id: string) => {
+            if (!id.includes('node_modules')) return undefined;
+            const chunkGroups: Record<string, string[]> = {
+              // Split React and React-DOM into separate chunk
+              'react-vendor': ['react', 'react-dom', 'react-router-dom'],
+              // Split Mapbox (large mapping library) into separate chunk
+              'mapbox': ['mapbox-gl', '@mapbox/mapbox-gl-geocoder', '@mapbox/mapbox-gl-draw'],
+              // Split Azure SDKs into separate chunk
+              'azure': ['@azure/msal-browser', '@azure/msal-react', '@azure/data-tables', '@azure/web-pubsub-client'],
+              // Split UI libraries into separate chunk
+              'ui-libs': ['@dnd-kit/core', '@dnd-kit/sortable', '@dnd-kit/utilities', 'qrcode.react'],
+              // Split Socket.IO into separate chunk
+              'realtime': ['socket.io-client'],
+              // Split date utilities
+              'date-utils': ['date-fns'],
+            };
+            for (const [chunk, packages] of Object.entries(chunkGroups)) {
+              if (packages.some((pkg) => id.includes(`node_modules/${pkg}/`))) {
+                return chunk;
+              }
+            }
+            return undefined;
           },
         },
       },


### PR DESCRIPTION
Implements the actionable open issues in one pass, plus the deploy-breaking build fix.

## 🔥 Deploy fix (#368, #369)
The two failed `Deploy to Azure App Service` runs on `main` were caused by the recent dependency bumps: **Vite 8 (Rolldown) no longer accepts the object form of `rollupOptions.output.manualChunks`**, so `tsc -b` failed in CI. `vite.config.ts` now uses the equivalent function form. Verified: `npm run build` passes.

## 📤 Data export (#152) — closes #152
- New `src/utils/routeExport.ts` (pure, unit-tested) + `ExportMenu` component.
- Single-route export from **RouteDetail** and bulk export from the **Dashboard**:
  - **JSON** — versioned `fire-santa-run-backup` envelope (re-importable)
  - **CSV** — RFC 4180, one row per stop with route metadata + analytics fields
  - **KML** — waypoint Placemarks + route-path LineString (Google Earth / My Maps)
- **Print / save-as-PDF** route summary: brigade branding (logo + theme colour), Mapbox static-map overview, stop table with ETAs/notes, turn-by-turn instructions.

## 📥 Data import & restore (#153) — closes #153
- New `src/utils/routeImport.ts` + `ImportModal` on the Dashboard.
- Restores JSON backups; imports **GPX** (wpt + trk/rte) and **KML** (Placemarks + path). Track-only files get generated Start/Finish stops.
- Validation (coordinate ranges, schema, statuses) with per-route issue reporting; **duplicate detection** by id or name+date with per-route *skip / replace / import-as-copy* resolution; **preview before anything is saved**; imports are re-scoped to the active brigade.

## 💬 Multi-operator collaboration (#151)
- **Route comments** with timestamps and optional waypoint tagging (`RouteComments` in the RouteDetail info panel); comments persist on the Route so they flow through both backends unchanged.
- **Last-editor stamping** (`updatedAt` + `lastEditedBy`) on every save, shown in the route timeline.
- **Conflict detection** in the route editor: saving warns when someone else saved since you loaded (named), then last-edit-wins.
- Waypoint notes already existed in the editor; comments can now reference stops.
- *Not included:* live "currently editing" presence (needs a Web PubSub group per route on both backends — left as follow-up).

## ⏱️ Predictive ETA (#145)
- New `src/utils/etaPrediction.ts`: builds a **median correction factor** from completed-run history (actual vs estimated duration), robust to outliers, with **time-of-day blending** and a **low/medium/high confidence level** (sample count + factor spread).
- RouteDetail shows a "Predicted" duration stat with a ●●● confidence indicator and sample count.
- Completing a route from RouteDetail now records `actualDuration` (previously only NavigationView did), so history accumulates from either path. Deliberately transparent arithmetic rather than an ML dependency.

## 👥 Member management gaps (#150)
- **Suspend / reactivate** members: new `MembershipService.suspendMember` / `reactivateMember` (admins can't be suspended; self-suspension blocked) + UI with a SUSPENDED badge.
- Member cards now show **joined date and last login**.
- **Audit logging** added for promote/demote (role changes) and suspend/reactivate.

## 🔧 Backend parity (per CLAUDE.md)
Both `api/` (Functions, local) and `server/` (Hono, prod) route mappers now persist `comments`, `updatedAt`, `lastEditedBy` — and also `navigationSettings` + `rerouteCount`, which were **silently dropped by both backends before this PR** (pre-existing data-loss bug).

## ✅ Quality
- 33 new unit tests (export round-trips incl. KML→import, validation, duplicates, ETA model & confidence); **541/541 tests pass**
- `npm run lint` clean · `tsc -b` clean · `server/` and `api/` TypeScript compile · production `npm run build` passes

Closes #152, #153, #145. Addresses #150, #151, #368, #369.

Epics #140/#146/#345 track these items — this PR completes #144→#145 from #140 and #150–#153 from #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WQonMxp4ZPRo71Cuhvvcu

---
_Generated by [Claude Code](https://claude.ai/code/session_012WQonMxp4ZPRo71Cuhvvcu)_