### PR TITLE
Close out all open issues: editing presence, invitation delivery, realtime rate limiting

### DIFF
--- a/api/src/broadcast.ts
+++ b/api/src/broadcast.ts
@@ -16,6 +16,7 @@
 
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
 import { WebPubSubServiceClient } from '@azure/web-pubsub';
+import { checkRateLimit } from './rateLimit';
 
 const HUB_NAME = process.env.AZURE_WEBPUBSUB_HUB_NAME || 'santa_tracking';
 
@@ -31,6 +32,11 @@ interface LocationBroadcast {
 
 export async function broadcast(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
   try {
+    // Launch hardening (#345): navigation sends a location every 5s (12/min)
+    // plus presence heartbeats; 40/min blocks flooding with headroom to spare.
+    const limited = checkRateLimit(request, 'broadcast', 40, 60_000);
+    if (limited) return limited;
+
     // Parse request body
     const body = await request.json() as Partial<LocationBroadcast>;
 
@@ -132,8 +138,73 @@ export async function broadcast(request: HttpRequest, context: InvocationContext
   }
 }
 
+/**
+ * Editor presence (#151): relays "who is editing this route" heartbeats to
+ * the edit_{routeId} group. Kept separate from the public tracking group so
+ * editor identities never reach anonymous viewers.
+ */
+export async function broadcastEditorPresence(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
+  try {
+    const limited = checkRateLimit(request, 'broadcast', 40, 60_000);
+    if (limited) return limited;
+
+    const body = await request.json() as {
+      routeId?: string;
+      userId?: string;
+      userName?: string;
+      action?: string;
+    };
+
+    if (!body.routeId || typeof body.routeId !== 'string') {
+      return { status: 400, jsonBody: { error: 'Missing required field: routeId' } };
+    }
+    if (!body.userId || typeof body.userId !== 'string') {
+      return { status: 400, jsonBody: { error: 'Missing required field: userId' } };
+    }
+    if (body.action !== 'editing' && body.action !== 'left') {
+      return { status: 400, jsonBody: { error: 'Invalid action. Must be "editing" or "left"' } };
+    }
+
+    const connectionString = process.env.AZURE_WEBPUBSUB_CONNECTION_STRING;
+    if (!connectionString) {
+      context.error('AZURE_WEBPUBSUB_CONNECTION_STRING is not configured');
+      return { status: 500, jsonBody: { error: 'Web PubSub service is not configured' } };
+    }
+
+    const serviceClient = new WebPubSubServiceClient(connectionString, HUB_NAME);
+    const groupName = `edit_${body.routeId}`;
+
+    const message = {
+      type: 'editor-presence',
+      routeId: body.routeId,
+      userId: body.userId,
+      userName: String(body.userName || 'A brigade member').slice(0, 80),
+      action: body.action,
+    };
+
+    await serviceClient.group(groupName).sendToAll(message);
+    return { status: 200, jsonBody: { success: true } };
+  } catch (error) {
+    context.error('Error broadcasting editor presence:', error);
+    return {
+      status: 500,
+      jsonBody: {
+        error: 'Failed to broadcast editor presence',
+        message: error instanceof Error ? error.message : 'Unknown error'
+      }
+    };
+  }
+}
+
 app.http('broadcast', {
   methods: ['POST'],
   authLevel: 'anonymous',
   handler: broadcast
+});
+
+app.http('broadcast-editor-presence', {
+  methods: ['POST'],
+  authLevel: 'anonymous',
+  route: 'broadcast/editor-presence',
+  handler: broadcastEditorPresence
 });

--- a/api/src/negotiate.ts
+++ b/api/src/negotiate.ts
@@ -13,11 +13,17 @@
 
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
 import { WebPubSubServiceClient } from '@azure/web-pubsub';
+import { checkRateLimit } from './rateLimit';
 
 const HUB_NAME = process.env.AZURE_WEBPUBSUB_HUB_NAME || 'santa_tracking';
 
 export async function negotiate(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
   try {
+    // Launch hardening (#345): clients negotiate once per session, so 20/min
+    // per IP is generous while blocking token-minting floods.
+    const limited = checkRateLimit(request, 'negotiate', 20, 60_000);
+    if (limited) return limited;
+
     // Get query parameters
     const routeId = request.query.get('routeId');
     const role = request.query.get('role') || 'viewer';
@@ -33,11 +39,11 @@ export async function negotiate(request: HttpRequest, context: InvocationContext
     }
 
     // Validate role
-    if (role !== 'viewer' && role !== 'broadcaster') {
+    if (role !== 'viewer' && role !== 'broadcaster' && role !== 'editor') {
       return {
         status: 400,
         jsonBody: {
-          error: 'Invalid role. Must be "viewer" or "broadcaster"'
+          error: 'Invalid role. Must be "viewer", "broadcaster" or "editor"'
         }
       };
     }
@@ -58,8 +64,9 @@ export async function negotiate(request: HttpRequest, context: InvocationContext
     // Create Web PubSub service client
     const serviceClient = new WebPubSubServiceClient(connectionString, HUB_NAME);
 
-    // Generate group name for route
-    const groupName = `route_${routeId}`;
+    // Generate group name for route. Editors join a separate presence group
+    // so editor identities are never delivered to anonymous public viewers.
+    const groupName = role === 'editor' ? `edit_${routeId}` : `route_${routeId}`;
 
     // Configure token options based on role
     const tokenOptions = {

--- a/api/src/rateLimit.ts
+++ b/api/src/rateLimit.ts
@@ -1,0 +1,71 @@
+/**
+ * Fixed-window in-memory rate limiter for the realtime Functions
+ * (/api/negotiate, /api/broadcast*) — launch-hardening item from the v1.0
+ * epic. Keyed by client IP + limiter name. Mirrors server/src/utils/rateLimit.ts.
+ *
+ * State is per-instance: on scaled-out Functions each instance enforces the
+ * limit independently — acceptable as an abuse brake rather than a strict
+ * global quota.
+ */
+
+import { HttpRequest, HttpResponseInit } from '@azure/functions';
+
+interface WindowEntry {
+  count: number;
+  windowStart: number;
+}
+
+const buckets = new Map<string, WindowEntry>();
+
+const MAX_TRACKED_KEYS = 10000;
+
+function clientIp(request: HttpRequest): string {
+  const forwarded = request.headers.get('x-forwarded-for');
+  if (forwarded) return forwarded.split(',')[0].trim();
+  return request.headers.get('x-client-ip') || 'unknown';
+}
+
+/**
+ * Check the rate limit for a request. Returns a 429 response when the client
+ * has exceeded the limit, or null when the request may proceed.
+ */
+export function checkRateLimit(
+  request: HttpRequest,
+  name: string,
+  limit: number,
+  windowMs: number
+): HttpResponseInit | null {
+  const key = `${name}:${clientIp(request)}`;
+  const now = Date.now();
+
+  let entry = buckets.get(key);
+  if (!entry || now - entry.windowStart >= windowMs) {
+    entry = { count: 0, windowStart: now };
+    if (!buckets.has(key) && buckets.size >= MAX_TRACKED_KEYS) {
+      for (const [k, v] of buckets) {
+        if (now - v.windowStart >= windowMs) buckets.delete(k);
+      }
+      // Still full → fail open rather than letting limiter overflow block
+      // legitimate clients.
+      if (buckets.size >= MAX_TRACKED_KEYS) return null;
+    }
+    buckets.set(key, entry);
+  }
+
+  entry.count++;
+  if (entry.count > limit) {
+    const retryAfterSeconds = Math.max(1, Math.ceil((entry.windowStart + windowMs - now) / 1000));
+    return {
+      status: 429,
+      headers: { 'Retry-After': String(retryAfterSeconds) },
+      jsonBody: { error: 'Too many requests — please slow down' },
+    };
+  }
+
+  return null;
+}
+
+/** Test hook: reset all limiter state. */
+export function resetRateLimits(): void {
+  buckets.clear();
+}

--- a/server/src/routes/broadcast.ts
+++ b/server/src/routes/broadcast.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Hono } from 'hono';
 import { WebPubSubServiceClient } from '@azure/web-pubsub';
+import { rateLimit } from '../utils/rateLimit.js';
 
 const HUB_NAME = process.env.AZURE_WEBPUBSUB_HUB_NAME || 'santa_tracking';
 
@@ -15,6 +16,12 @@ interface LocationBroadcast {
 }
 
 export const broadcastRouter = new Hono();
+
+// Launch hardening (#345): cap broadcast volume per client. Navigation sends
+// a location every 5s (12/min) and presence heartbeats every 15s (4/min);
+// 40/min leaves ample headroom for retries without allowing flooding.
+broadcastRouter.use('/broadcast', rateLimit({ name: 'broadcast', limit: 40, windowMs: 60_000 }));
+broadcastRouter.use('/broadcast/*', rateLimit({ name: 'broadcast', limit: 40, windowMs: 60_000 }));
 
 broadcastRouter.post('/broadcast', async (c) => {
   try {
@@ -65,6 +72,55 @@ broadcastRouter.post('/broadcast', async (c) => {
   } catch (error: any) {
     console.error('Error broadcasting location:', error);
     return c.json({ error: 'Failed to broadcast location', message: error instanceof Error ? error.message : 'Unknown error' }, 500);
+  }
+});
+
+/**
+ * Editor presence (#151): relays "who is editing this route" heartbeats to
+ * the edit_{routeId} group. Kept separate from the public tracking group so
+ * editor identities never reach anonymous viewers.
+ */
+broadcastRouter.post('/broadcast/editor-presence', async (c) => {
+  try {
+    const body = await c.req.json() as {
+      routeId?: string;
+      userId?: string;
+      userName?: string;
+      action?: string;
+    };
+
+    if (!body.routeId || typeof body.routeId !== 'string') {
+      return c.json({ error: 'Missing required field: routeId' }, 400);
+    }
+    if (!body.userId || typeof body.userId !== 'string') {
+      return c.json({ error: 'Missing required field: userId' }, 400);
+    }
+    if (body.action !== 'editing' && body.action !== 'left') {
+      return c.json({ error: 'Invalid action. Must be "editing" or "left"' }, 400);
+    }
+
+    const connectionString = process.env.AZURE_WEBPUBSUB_CONNECTION_STRING;
+    if (!connectionString) {
+      console.error('AZURE_WEBPUBSUB_CONNECTION_STRING is not configured');
+      return c.json({ error: 'Web PubSub service is not configured' }, 500);
+    }
+
+    const serviceClient = new WebPubSubServiceClient(connectionString, HUB_NAME);
+    const groupName = `edit_${body.routeId}`;
+
+    const message = {
+      type: 'editor-presence',
+      routeId: body.routeId,
+      userId: body.userId,
+      userName: String(body.userName || 'A brigade member').slice(0, 80),
+      action: body.action,
+    };
+
+    await serviceClient.group(groupName).sendToAll(message);
+    return c.json({ success: true }, 200);
+  } catch (error: any) {
+    console.error('Error broadcasting editor presence:', error);
+    return c.json({ error: 'Failed to broadcast editor presence', message: error instanceof Error ? error.message : 'Unknown error' }, 500);
   }
 });
 

--- a/server/src/routes/negotiate.ts
+++ b/server/src/routes/negotiate.ts
@@ -1,10 +1,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Hono } from 'hono';
 import { WebPubSubServiceClient } from '@azure/web-pubsub';
+import { rateLimit } from '../utils/rateLimit.js';
 
 const HUB_NAME = process.env.AZURE_WEBPUBSUB_HUB_NAME || 'santa_tracking';
 
 export const negotiateRouter = new Hono();
+
+// Launch hardening (#345): cap connection-token requests per client.
+// Legitimate clients negotiate once per session (plus rare reconnects).
+negotiateRouter.use('/negotiate', rateLimit({ name: 'negotiate', limit: 20, windowMs: 60_000 }));
 
 async function handleNegotiate(c: any) {
   try {
@@ -15,8 +20,8 @@ async function handleNegotiate(c: any) {
       return c.json({ error: 'Missing required parameter: routeId' }, 400);
     }
 
-    if (role !== 'viewer' && role !== 'broadcaster') {
-      return c.json({ error: 'Invalid role. Must be "viewer" or "broadcaster"' }, 400);
+    if (role !== 'viewer' && role !== 'broadcaster' && role !== 'editor') {
+      return c.json({ error: 'Invalid role. Must be "viewer", "broadcaster" or "editor"' }, 400);
     }
 
     const connectionString = process.env.AZURE_WEBPUBSUB_CONNECTION_STRING;
@@ -26,7 +31,9 @@ async function handleNegotiate(c: any) {
     }
 
     const serviceClient = new WebPubSubServiceClient(connectionString, HUB_NAME);
-    const groupName = `route_${routeId}`;
+    // Editors join a separate presence group so editor identities are never
+    // delivered to anonymous public viewers on the tracking group.
+    const groupName = role === 'editor' ? `edit_${routeId}` : `route_${routeId}`;
 
     const tokenOptions = {
       groups: [groupName],

--- a/server/src/utils/rateLimit.ts
+++ b/server/src/utils/rateLimit.ts
@@ -1,0 +1,79 @@
+import type { Context, Next } from 'hono';
+
+/**
+ * Fixed-window in-memory rate limiter for the realtime endpoints
+ * (/api/negotiate, /api/broadcast*) — the launch-hardening item from the
+ * v1.0 epic. Keyed by client IP + limiter name.
+ *
+ * In-memory state is per-process: on a scaled-out App Service each instance
+ * enforces the limit independently, which is acceptable as an abuse brake
+ * (the intent here) rather than a strict global quota. Front Door / App
+ * Service-level rules can be layered on top for network-level enforcement.
+ */
+
+interface WindowEntry {
+  count: number;
+  windowStart: number;
+}
+
+const buckets = new Map<string, WindowEntry>();
+
+/** Cap total tracked keys so an attacker rotating IPs can't grow memory unboundedly. */
+const MAX_TRACKED_KEYS = 10000;
+
+function clientIp(c: Context): string {
+  // App Service / Front Door put the client in the first x-forwarded-for hop
+  const forwarded = c.req.header('x-forwarded-for');
+  if (forwarded) return forwarded.split(',')[0].trim();
+  return c.req.header('x-client-ip') || 'unknown';
+}
+
+export interface RateLimitOptions {
+  /** Limiter name — separates buckets between endpoints */
+  name: string;
+  /** Max requests per window per client */
+  limit: number;
+  /** Window length in milliseconds */
+  windowMs: number;
+}
+
+/** Hono middleware enforcing a fixed-window per-IP rate limit. */
+export function rateLimit({ name, limit, windowMs }: RateLimitOptions) {
+  return async (c: Context, next: Next) => {
+    const key = `${name}:${clientIp(c)}`;
+    const now = Date.now();
+
+    let entry = buckets.get(key);
+    if (!entry || now - entry.windowStart >= windowMs) {
+      entry = { count: 0, windowStart: now };
+      // Opportunistic cleanup: when at capacity, drop expired entries first
+      if (!buckets.has(key) && buckets.size >= MAX_TRACKED_KEYS) {
+        for (const [k, v] of buckets) {
+          if (now - v.windowStart >= windowMs) buckets.delete(k);
+        }
+        // Still full → refuse new tracking keys rather than grow: allow the
+        // request through (fail-open) since dropping traffic on limiter
+        // overflow would let an attacker DoS legitimate clients.
+        if (buckets.size >= MAX_TRACKED_KEYS) {
+          await next();
+          return;
+        }
+      }
+      buckets.set(key, entry);
+    }
+
+    entry.count++;
+    if (entry.count > limit) {
+      const retryAfterSeconds = Math.max(1, Math.ceil((entry.windowStart + windowMs - now) / 1000));
+      c.header('Retry-After', String(retryAfterSeconds));
+      return c.json({ error: 'Too many requests — please slow down' }, 429);
+    }
+
+    await next();
+  };
+}
+
+/** Test hook: reset all limiter state. */
+export function resetRateLimits(): void {
+  buckets.clear();
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,6 +4,8 @@ export { useGeolocation } from './useGeolocation';
 export { useNavigation } from './useNavigation';
 export { useWebPubSub } from './useWebPubSub';
 export { useLocationBroadcast } from './useLocationBroadcast';
+export { useEditingPresence } from './useEditingPresence';
+export type { EditorPresence } from './useEditingPresence';
 export { useUserProfile } from './useUserProfile';
 export { useTemplates } from './useTemplates';
 export { useReverseGeocode } from './useReverseGeocode';

--- a/src/hooks/useEditingPresence.ts
+++ b/src/hooks/useEditingPresence.ts
@@ -1,0 +1,160 @@
+/**
+ * useEditingPresence hook — shows who else is currently editing a route.
+ *
+ * Editors of the same route exchange lightweight presence heartbeats over a
+ * dedicated channel (separate from the public tracking group so editor names
+ * never reach anonymous viewers):
+ * - Dev mode: BroadcastChannel `santa-editing-{routeId}` (cross-tab).
+ * - Production: Web PubSub group `edit_{routeId}` — received via a
+ *   negotiate(role=editor) connection, sent via POST /api/broadcast/editor-presence.
+ *
+ * Peers that miss two heartbeats are considered gone.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { WebPubSubClient } from '@azure/web-pubsub-client';
+
+const isDevMode = import.meta.env.VITE_DEV_MODE === 'true';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
+
+const HEARTBEAT_INTERVAL_MS = 15000;
+const STALE_AFTER_MS = 40000; // just over two missed heartbeats
+
+export interface EditorPresence {
+  userId: string;
+  userName: string;
+  /** Last heartbeat received (epoch ms, local clock) */
+  lastSeen: number;
+}
+
+interface PresenceMessage {
+  type: 'editor-presence';
+  routeId: string;
+  userId: string;
+  userName: string;
+  action: 'editing' | 'left';
+}
+
+interface UseEditingPresenceOptions {
+  routeId: string;
+  user: { id: string; name: string } | null;
+  /** Disable for new/unsaved routes */
+  enabled?: boolean;
+}
+
+export function useEditingPresence({ routeId, user, enabled = true }: UseEditingPresenceOptions) {
+  const [peers, setPeers] = useState<EditorPresence[]>([]);
+  const peersRef = useRef<Map<string, EditorPresence>>(new Map());
+
+  useEffect(() => {
+    if (!enabled || !routeId || !user) return;
+
+    const self = { id: user.id, name: user.name };
+    let disposed = false;
+    let channel: BroadcastChannel | null = null;
+    let client: WebPubSubClient | null = null;
+    let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+    let sweepTimer: ReturnType<typeof setInterval> | null = null;
+
+    const publishPeers = () => {
+      setPeers([...peersRef.current.values()].sort((a, b) => a.userName.localeCompare(b.userName)));
+    };
+
+    const handleMessage = (data: unknown) => {
+      const msg = data as PresenceMessage;
+      if (!msg || msg.type !== 'editor-presence' || msg.routeId !== routeId) return;
+      if (msg.userId === self.id) return;
+      if (msg.action === 'left') {
+        peersRef.current.delete(msg.userId);
+      } else {
+        peersRef.current.set(msg.userId, {
+          userId: msg.userId,
+          userName: msg.userName,
+          lastSeen: Date.now(),
+        });
+      }
+      publishPeers();
+    };
+
+    const buildMessage = (action: PresenceMessage['action']): PresenceMessage => ({
+      type: 'editor-presence',
+      routeId,
+      userId: self.id,
+      userName: self.name,
+      action,
+    });
+
+    const sendPresence = (action: PresenceMessage['action']) => {
+      if (isDevMode) {
+        channel?.postMessage(buildMessage(action));
+      } else {
+        // keepalive lets the 'left' message survive page teardown
+        fetch(`${API_BASE_URL}/broadcast/editor-presence`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(buildMessage(action)),
+          keepalive: action === 'left',
+        }).catch(() => {
+          // Presence is best-effort; never surface errors to the editor
+        });
+      }
+    };
+
+    const startHeartbeat = () => {
+      sendPresence('editing');
+      heartbeatTimer = setInterval(() => sendPresence('editing'), HEARTBEAT_INTERVAL_MS);
+      sweepTimer = setInterval(() => {
+        const cutoff = Date.now() - STALE_AFTER_MS;
+        let changed = false;
+        for (const [id, peer] of peersRef.current) {
+          if (peer.lastSeen < cutoff) {
+            peersRef.current.delete(id);
+            changed = true;
+          }
+        }
+        if (changed) publishPeers();
+      }, HEARTBEAT_INTERVAL_MS);
+    };
+
+    if (isDevMode) {
+      channel = new BroadcastChannel(`santa-editing-${routeId}`);
+      channel.onmessage = (event) => handleMessage(event.data);
+      startHeartbeat();
+    } else {
+      (async () => {
+        try {
+          const response = await fetch(
+            `${API_BASE_URL}/negotiate?routeId=${encodeURIComponent(routeId)}&role=editor`
+          );
+          if (!response.ok) throw new Error(`negotiate failed: ${response.status}`);
+          const { url } = await response.json();
+          if (disposed) return;
+
+          client = new WebPubSubClient(url);
+          client.on('group-message', (event) => handleMessage(event.message.data));
+          await client.start();
+          if (disposed) {
+            client.stop();
+            return;
+          }
+          startHeartbeat();
+        } catch (error) {
+          console.error('[EditingPresence] Failed to connect:', error);
+        }
+      })();
+    }
+
+    return () => {
+      disposed = true;
+      if (heartbeatTimer) clearInterval(heartbeatTimer);
+      if (sweepTimer) clearInterval(sweepTimer);
+      sendPresence('left');
+      channel?.close();
+      client?.stop();
+      peersRef.current = new Map();
+      setPeers([]);
+    };
+  }, [routeId, user?.id, user?.name, enabled]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return { activeEditors: peers };
+}

--- a/src/pages/MemberManagementPage.tsx
+++ b/src/pages/MemberManagementPage.tsx
@@ -473,10 +473,7 @@ export function MemberManagementPage() {
           brigadeId={brigadeId!}
           currentUser={authUser}
           onClose={() => setShowInviteModal(false)}
-          onSuccess={async () => {
-            setShowInviteModal(false);
-            await loadData();
-          }}
+          onSuccess={loadData}
         />
       )}
       </AppLayout>
@@ -565,6 +562,8 @@ function PendingInvitationCard({
   invitation: MemberInvitation;
   onCancel: () => void;
 }) {
+  const [copied, setCopied] = useState(false);
+
   return (
     <div style={{
       display: 'flex',
@@ -580,27 +579,53 @@ function PendingInvitationCard({
           {invitation.email}
         </div>
         <div style={{ fontSize: '0.875rem', color: '#616161' }}>
-          Invited {new Date(invitation.invitedAt).toLocaleDateString()}
+          Invited {new Date(invitation.invitedAt).toLocaleDateString()} · expires {new Date(invitation.expiresAt).toLocaleDateString()}
         </div>
         <div style={{ marginTop: '0.5rem' }}>
           <RoleBadge role={invitation.role} size="small" />
         </div>
       </div>
-      <button
-        onClick={onCancel}
-        style={{
-          padding: '0.5rem 1rem',
-          background: '#EEEEEE',
-          color: '#616161',
-          border: '1px solid #E0E0E0',
-          borderRadius: '8px',
-          fontSize: '0.875rem',
-          fontWeight: 600,
-          cursor: 'pointer',
-        }}
-      >
-        Cancel
-      </button>
+      <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', justifyContent: 'flex-end' }}>
+        <button
+          onClick={async () => {
+            const link = invitationLink(invitation.token);
+            try {
+              await navigator.clipboard.writeText(link);
+              setCopied(true);
+              setTimeout(() => setCopied(false), 2000);
+            } catch {
+              prompt('Copy this invitation link:', link);
+            }
+          }}
+          style={{
+            padding: '0.5rem 1rem',
+            background: copied ? COLORS.success : 'white',
+            color: copied ? 'white' : COLORS.primary,
+            border: `1px solid ${copied ? COLORS.success : COLORS.primary}`,
+            borderRadius: '8px',
+            fontSize: '0.875rem',
+            fontWeight: 600,
+            cursor: 'pointer',
+          }}
+        >
+          {copied ? '✓ Copied' : '📋 Copy link'}
+        </button>
+        <button
+          onClick={onCancel}
+          style={{
+            padding: '0.5rem 1rem',
+            background: '#EEEEEE',
+            color: '#616161',
+            border: '1px solid #E0E0E0',
+            borderRadius: '8px',
+            fontSize: '0.875rem',
+            fontWeight: 600,
+            cursor: 'pointer',
+          }}
+        >
+          Cancel
+        </button>
+      </div>
     </div>
   );
 }
@@ -781,6 +806,10 @@ function InviteModal({
   const [message, setMessage] = useState('');
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // After creation the modal switches to a share step: there is no outbound
+  // email service, so the inviter delivers the link (copy or email app).
+  const [createdInvitation, setCreatedInvitation] = useState<MemberInvitation | null>(null);
+  const [linkCopied, setLinkCopied] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -801,8 +830,9 @@ function InviteModal({
         message.trim() || undefined
       );
 
-      if (result.success) {
+      if (result.success && result.data) {
         logMemberInvited(currentUser.id, currentUser.email, email.trim(), brigadeId, role);
+        setCreatedInvitation(result.data);
         onSuccess();
       } else {
         setError(result.error || 'Failed to send invitation');
@@ -846,6 +876,15 @@ function InviteModal({
           ✉️ Invite Member
         </h2>
 
+        {createdInvitation ? (
+          <InvitationShareStep
+            invitation={createdInvitation}
+            inviterName={currentUser.name || currentUser.email}
+            linkCopied={linkCopied}
+            onCopied={() => setLinkCopied(true)}
+            onDone={onClose}
+          />
+        ) : (
         <form onSubmit={handleSubmit}>
           <div style={{ marginBottom: '1rem' }}>
             <label
@@ -973,6 +1012,141 @@ function InviteModal({
             </button>
           </div>
         </form>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Build the acceptance URL for an invitation token. */
+function invitationLink(token: string): string {
+  return `${window.location.origin}/invitations/${token}`;
+}
+
+/**
+ * Share step shown after an invitation is created (#150). The app has no
+ * outbound email service, so the inviter delivers the link themselves —
+ * copy it, or open a pre-filled email in their mail app.
+ */
+function InvitationShareStep({
+  invitation,
+  inviterName,
+  linkCopied,
+  onCopied,
+  onDone,
+}: {
+  invitation: MemberInvitation;
+  inviterName: string;
+  linkCopied: boolean;
+  onCopied: () => void;
+  onDone: () => void;
+}) {
+  const link = invitationLink(invitation.token);
+  const expiryDate = new Date(invitation.expiresAt).toLocaleDateString();
+  const mailtoHref = `mailto:${encodeURIComponent(invitation.email)}`
+    + `?subject=${encodeURIComponent("You're invited to join our brigade on Fire Santa Run")}`
+    + `&body=${encodeURIComponent(
+      `G'day!\n\n${inviterName} has invited you to join their brigade on Fire Santa Run as ${invitation.role === 'operator' ? 'an operator' : 'a viewer'}.`
+      + (invitation.personalMessage ? `\n\n"${invitation.personalMessage}"` : '')
+      + `\n\nAccept your invitation here (link expires ${expiryDate}):\n${link}\n\n🎅`
+    )}`;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(link);
+      onCopied();
+    } catch {
+      // Clipboard can be unavailable (permissions/http) — select-and-copy fallback
+      prompt('Copy this invitation link:', link);
+    }
+  };
+
+  return (
+    <div>
+      <div
+        style={{
+          padding: '0.75rem',
+          backgroundColor: '#E8F5E9',
+          color: '#2E7D32',
+          borderRadius: '8px',
+          marginBottom: '1rem',
+          fontSize: '0.9rem',
+        }}
+      >
+        ✅ Invitation created for <strong>{invitation.email}</strong>. Share the link below —
+        it expires on <strong>{expiryDate}</strong> (7 days).
+      </div>
+
+      <label htmlFor="invite-link" style={{ display: 'block', marginBottom: '0.5rem', fontWeight: 600 }}>
+        Invitation link
+      </label>
+      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
+        <input
+          id="invite-link"
+          type="text"
+          readOnly
+          value={link}
+          onFocus={(e) => e.target.select()}
+          style={{
+            flex: 1,
+            padding: '0.75rem',
+            border: '1px solid #E0E0E0',
+            borderRadius: '8px',
+            fontSize: '0.85rem',
+            color: '#616161',
+          }}
+        />
+        <button
+          type="button"
+          onClick={handleCopy}
+          style={{
+            padding: '0.75rem 1rem',
+            background: linkCopied ? COLORS.success : `linear-gradient(135deg, ${COLORS.primary} 0%, ${COLORS.primaryDark} 100%)`,
+            color: 'white',
+            border: 'none',
+            borderRadius: '8px',
+            fontSize: '0.9rem',
+            fontWeight: 600,
+            cursor: 'pointer',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {linkCopied ? '✓ Copied' : '📋 Copy'}
+        </button>
+      </div>
+
+      <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'flex-end', flexWrap: 'wrap' }}>
+        <a
+          href={mailtoHref}
+          style={{
+            padding: '0.75rem 1.5rem',
+            background: 'white',
+            color: COLORS.primary,
+            border: `2px solid ${COLORS.primary}`,
+            borderRadius: '8px',
+            fontSize: '1rem',
+            fontWeight: 600,
+            textDecoration: 'none',
+          }}
+        >
+          ✉️ Send via email app
+        </a>
+        <button
+          type="button"
+          onClick={onDone}
+          style={{
+            padding: '0.75rem 1.5rem',
+            background: `linear-gradient(135deg, ${COLORS.primary} 0%, ${COLORS.primaryDark} 100%)`,
+            color: 'white',
+            border: 'none',
+            borderRadius: '8px',
+            fontSize: '1rem',
+            fontWeight: 600,
+            cursor: 'pointer',
+          }}
+        >
+          Done
+        </button>
       </div>
     </div>
   );

--- a/src/pages/RouteEditor.tsx
+++ b/src/pages/RouteEditor.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth, useBrigade } from '../context';
 import { useRoutes, useRouteEditor } from '../hooks';
 import { useTemplates } from '../hooks/useTemplates';
+import { useEditingPresence } from '../hooks/useEditingPresence';
 import { MapView, WaypointList, AddressSearch, ShareModal } from '../components';
 import { createNewRoute, generateShareableLink, canPublishRoute, generateWaypointId, generateTemplateId, DEFAULT_NAVIGATION_SETTINGS } from '../utils/routeHelpers';
 import { reverseGeocode, type GeocodingResult } from '../utils/mapbox';
@@ -88,6 +89,14 @@ export function RouteEditor({ routeId, mode }: RouteEditorProps) {
     optimizationError,
     optimizationComparison,
   } = useRouteEditor(initialRoute || createNewRoute(user?.brigadeId || '', user?.email));
+
+  // Multi-operator presence (#151): announce this editor and see who else has
+  // the same saved route open. Disabled for unsaved new routes.
+  const { activeEditors } = useEditingPresence({
+    routeId: routeId || '',
+    user: user ? { id: user.id, name: user.name || user.email } : null,
+    enabled: mode === 'edit' && !!routeId,
+  });
 
   // Tracks which route id has been pushed into the editor, so re-runs of the
   // load effect (e.g. auth context identity changes) never clobber edits.
@@ -423,6 +432,33 @@ export function RouteEditor({ routeId, mode }: RouteEditorProps) {
           maxWidth: '90%',
         }}>
           {saveError}
+        </div>
+      )}
+
+      {/* Multi-operator presence (#151): who else has this route open */}
+      {activeEditors.length > 0 && (
+        <div
+          role="status"
+          style={{
+            position: 'absolute',
+            top: '6rem',
+            right: '1rem',
+            padding: '0.6rem 1rem',
+            backgroundColor: 'rgba(255, 249, 230, 0.95)',
+            color: '#B26A00',
+            border: '1px solid var(--summer-gold)',
+            borderRadius: '12px',
+            boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
+            zIndex: 1001,
+            maxWidth: 'min(320px, 80vw)',
+            fontSize: '0.85rem',
+            fontWeight: 600,
+          }}
+        >
+          <span aria-hidden="true">👀</span>{' '}
+          {activeEditors.length === 1
+            ? `${activeEditors[0].userName} is also editing this route`
+            : `${activeEditors.map(e => e.userName).join(', ')} are also editing this route`}
         </div>
       )}
 


### PR DESCRIPTION
Implements the remaining gaps across all 8 open issues and closes them.

## 👀 Editing presence — the last piece of multi-operator collaboration
**Closes #151.** Comments, waypoint notes, last-edit-wins conflict detection and last-editor stamping shipped in #372; this adds the final unmet criterion — *show who is currently editing*:
- New `useEditingPresence` hook: editors of the same saved route exchange 15s heartbeats and appear in a live "👀 Jane is also editing this route" banner in the RouteEditor (peers expire after two missed beats, and send a `left` signal on exit via `keepalive` fetch).
- Presence travels over a **dedicated `edit_{routeId}` Web PubSub group** — negotiate gains an `editor` role and both backends gain `POST /api/broadcast/editor-presence` — so editor identities are never delivered to anonymous viewers on the public tracking group. Dev mode uses a `BroadcastChannel`.

## ✉️ Invitation delivery — the real gap in member management
**Closes #150.** The management UI (roles, invites with 7-day expiry, approvals, suspend/reactivate, audit logging, last-login display) was completed across #349/#372 — but invitations were created with a token that **no one ever saw**: there is no outbound email service, so an invitee could never receive their link. Now:
- After creating an invitation, the modal switches to a **share step**: the acceptance link with a copy button, expiry date, and a pre-filled **"Send via email app"** mailto (includes the personal message).
- Pending invitation cards show the **expiry date** and a **copy-link** button, so links can be re-shared any time before they expire.

## 🚦 Rate limiting on realtime endpoints
**Closes #345** (final code item on the v1.0 launch epic; remaining epic items are ops — Lighthouse run, Azure alerts, pilot dry-run — tracked in MASTER_PLAN's launch checklist):
- Fixed-window per-IP limits in **both** backends (`server/` Hono middleware, `api/` Functions helper): `/api/negotiate` 20/min, `/api/broadcast*` 40/min (navigation sends 12 location updates/min + 4 presence beats/min, so ample headroom).
- 429 responses carry `Retry-After`; limiter memory is bounded (10k keys) and fails open on overflow so the limiter itself can't be weaponised.

## ✅ Issues closed without new code (work already merged)
- **Closes #145** — predictive ETA shipped in #372 (history-based duration correction, time-of-day blending, confidence display); stayed open only because the merge lacked a closing keyword.
- **Fixes #368, Fixes #369** — the failed deploys were the Vite 8 `manualChunks` build break, fixed in #372; subsequent deploy runs build cleanly.
- **Closes #140** — Release 3.2 epic: all sub-issues done (#141–#144 previously; #145 in #372).
- **Closes #146** — Release 4 epic: all sub-issues done (#147–#149, #154 in #349; #152/#153 in #372; #150/#151 completed here).

## Verification
- 557/557 unit tests pass · lint 0 errors (42 pre-existing baseline warnings documented in #361) · root/`server/`/`api/` TypeScript all compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WQonMxp4ZPRo71Cuhvvcu

---
_Generated by [Claude Code](https://claude.ai/code/session_012WQonMxp4ZPRo71Cuhvvcu)_