### PR TITLE
Fix run edit navigation returning to dashboard

### DIFF
--- a/src/pages/RouteEditor.tsx
+++ b/src/pages/RouteEditor.tsx
@@ -111,6 +111,9 @@ export function RouteEditor({ routeId, mode }: RouteEditorProps) {
   useEffect(() => {
     if (mode === 'edit' && routeId) {
       if (loadedRouteIdRef.current === routeId) return;
+      // Don't load the route until brigade context finishes loading to ensure
+      // getRoute has access to a properly initialized user brigadeId
+      if (brigadeLoading) return;
       setIsLoading(true);
       getRoute(routeId).then(route => {
         if (route) {
@@ -127,7 +130,7 @@ export function RouteEditor({ routeId, mode }: RouteEditorProps) {
       setInitialRoute(fresh);
       resetRoute(fresh);
     }
-  }, [mode, routeId, getRoute, user, navigate, resetRoute, initialRoute]);
+  }, [mode, routeId, getRoute, user, navigate, resetRoute, initialRoute, brigadeLoading]);
 
   const handleMapClick = useCallback(async (coordinates: [number, number]) => {
     try {


### PR DESCRIPTION
## Summary

Fixed an issue where clicking 'edit' on an existing run from the dashboard or route details page would immediately return to the dashboard instead of opening the run in edit mode.

## Root Cause

The `RouteEditor` component's `useEffect` was attempting to fetch the route before the brigade context (`brigadeLoading`) finished initializing. This caused `getRoute()` to return `null` because the user's `brigadeId` wasn't available yet, triggering a redirect to the dashboard.

## Fix

Added a check to wait for `brigadeLoading` to be `false` before attempting to fetch the route in edit mode. This ensures the user context is fully initialized and has a valid `brigadeId` before calling `getRoute()`.

### Changes Made

- Added early return in the edit mode route loading effect if `brigadeLoading` is still `true`
- Added `brigadeLoading` to the useEffect dependency array to ensure proper re-evaluation when brigade context updates

## Testing

The fix can be tested by:
1. Creating a new run
2. Navigating back to the dashboard
3. Clicking the "Edit" button on the run card
4. Verify the route editor opens instead of returning to the dashboard

Similar test can be done from the route details page by clicking the "Edit" button in the action panel.

---
_Generated by [Claude Code](https://claude.ai/code/session_018rZKkUWJ3nZw8PXeCQZvgC)_