### PR TITLE
Accept both current and stationkit.com.au origins during domain move

### DIFF
--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -140,6 +140,22 @@ is the audience and the marketing channel.
 
 ## Operational readiness
 
+- **Domain move to `santa.stationkit.com.au` (in progress, 2026-07-18).** Station
+  Manager's public branding/URL moved to `stationkit.com.au`; this app is moving
+  from its independent `firesantarun.com.au` domain to a `stationkit.com.au`
+  subdomain to match. **Shipped:** `server/src/app.ts`'s CORS allowlist now
+  accepts a comma-separated `CORS_ORIGIN` and defaults (prod) to both
+  `firesantarun.com.au` and `santa.stationkit.com.au` during the transition;
+  `infra/seed-secrets.sh` seeds that same two-origin default unless
+  `CORS_ORIGIN` is overridden. `APP_BASE_URL` (used to build outbound links —
+  SMS broadcasts, Stripe redirects, VAPID subject) deliberately still defaults
+  to `firesantarun.com.au` — don't flip it until DNS for the new subdomain is
+  actually live, or generated links 404. **Still open (infra/ops, not code):**
+  Cloudflare DNS + TLS for `santa.stationkit.com.au` and its Container Apps
+  custom-domain binding; once live, flip `APP_BASE_URL` and narrow
+  `CORS_ORIGIN` back to the single new origin, retiring `firesantarun.com.au`.
+  No functional Station Manager SSO integration exists in this repo today (no
+  code coupling beyond this domain/CORS alignment).
 - **Container Apps scale-to-zero.** `minReplicas: 0` off-season, flipped to
   1 for December via [`infra/scale-season.sh`](infra/scale-season.sh) so the
   first visitor of the season isn't stuck with a cold start mid-run.

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -40,6 +40,13 @@ VAPID_PRIVATE_KEY=
 # Contact URI sent to push services (optional; defaults to a mailto).
 VAPID_SUBJECT=
 
-# Optional: override the public origin used for CORS_ORIGIN / APP_BASE_URL.
+# Optional: override the public origin used for APP_BASE_URL (and CORS_ORIGIN
+# unless CORS_ORIGIN is set separately below).
 # Defaults: prod -> https://firesantarun.com.au, dev -> https://santarun-web-<suffix>.azurewebsites.net
 # APP_ORIGIN=
+
+# Optional: override the CORS allowlist (comma-separated origins). Defaults to
+# APP_ORIGIN in dev; in prod defaults to both the current domain and the
+# incoming stationkit.com.au subdomain during the suite rebrand transition:
+# https://firesantarun.com.au,https://santa.stationkit.com.au
+# CORS_ORIGIN=

--- a/infra/README.md
+++ b/infra/README.md
@@ -276,7 +276,8 @@ you provide.
 | `AZURE_STORAGE_CONNECTION_STRING` | Storage account primary connection string | read live from Azure |
 | `DEV_MODE` | `false` | fixed |
 | `NODE_ENV` / `PORT` | `production` / `8080` | fixed |
-| `CORS_ORIGIN` / `APP_BASE_URL` | Public origin (prod: `https://firesantarun.com.au`; dev: the Container App's auto-generated FQDN, or `APP_ORIGIN` override) | derived |
+| `APP_BASE_URL` | Public origin used for generated links (prod: `https://firesantarun.com.au`; dev: the Container App's auto-generated FQDN, or `APP_ORIGIN` override) | derived |
+| `CORS_ORIGIN` | Comma-separated CORS allowlist (prod default: `https://firesantarun.com.au,https://santa.stationkit.com.au` during the suite rebrand transition; dev: same as `APP_BASE_URL`) | derived, override with `CORS_ORIGIN` |
 | `STRIPE_SECRET_KEY` | Stripe secret key — **test** for dev, **live** for prod | `infra/.env.<env>` |
 | `STRIPE_WEBHOOK_SECRET` | Signing secret (`whsec_…`) for that environment's webhook endpoint | `infra/.env.<env>` |
 | `STRIPE_PRICE_ID` | Price id (`price_…`) of the subscription price (test vs live mode) | `infra/.env.<env>` |

--- a/infra/seed-secrets.sh
+++ b/infra/seed-secrets.sh
@@ -184,15 +184,23 @@ echo "✅ Storage connection string retrieved."
 
 if [[ "$ENVIRONMENT" == "prod" ]]; then
   DEFAULT_ORIGIN="https://firesantarun.com.au"
+  # CORS accepts both the current domain and the incoming stationkit.com.au
+  # subdomain during the suite rebrand transition — narrow this back to a
+  # single origin once DNS for santa.stationkit.com.au is live and traffic
+  # has cut over.
+  DEFAULT_CORS_ORIGIN="https://firesantarun.com.au,https://santa.stationkit.com.au"
 else
   CONTAINER_FQDN=$(az containerapp show \
     --name "$APP_NAME" \
     --resource-group "$RESOURCE_GROUP" \
     --query properties.configuration.ingress.fqdn --output tsv 2>/dev/null || true)
   DEFAULT_ORIGIN="${CONTAINER_FQDN:+https://$CONTAINER_FQDN}"
+  DEFAULT_CORS_ORIGIN="$DEFAULT_ORIGIN"
 fi
 APP_ORIGIN="$(resolve APP_ORIGIN)"
 APP_ORIGIN="${APP_ORIGIN:-$DEFAULT_ORIGIN}"
+CORS_ORIGIN_VALUE="$(resolve CORS_ORIGIN)"
+CORS_ORIGIN_VALUE="${CORS_ORIGIN_VALUE:-$DEFAULT_CORS_ORIGIN}"
 
 if [[ -z "$APP_ORIGIN" ]]; then
   echo "❌ Could not determine the app origin. Pass APP_ORIGIN=https://... or confirm the app deployed."
@@ -208,7 +216,7 @@ SETTINGS=(
   "DEV_MODE=false"
   "NODE_ENV=production"
   "PORT=8080"
-  "CORS_ORIGIN=$APP_ORIGIN"
+  "CORS_ORIGIN=$CORS_ORIGIN_VALUE"
   "APP_BASE_URL=$APP_ORIGIN"
 )
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -18,7 +18,15 @@ import { pushRouter } from './routes/push.js';
 import { auditRouter } from './routes/audit.js';
 
 const isDevMode = process.env.DEV_MODE === 'true';
-const ALLOWED_ORIGIN = process.env.CORS_ORIGIN || 'https://firesantarun.com.au';
+// CORS_ORIGIN may be a comma-separated list. Default covers both the current
+// production domain and the incoming stationkit.com.au subdomain during the
+// suite rebrand transition — drop firesantarun.com.au once DNS for
+// santa.stationkit.com.au is live and traffic has cut over.
+const ALLOWED_ORIGINS = (process.env.CORS_ORIGIN || 'https://firesantarun.com.au,https://santa.stationkit.com.au')
+  .split(',')
+  .map((o) => o.trim())
+  .filter(Boolean);
+const isAllowedOrigin = (origin: string | undefined): boolean => !!origin && ALLOWED_ORIGINS.includes(origin);
 
 export function createApp() {
   const app = new Hono();
@@ -28,8 +36,8 @@ export function createApp() {
   app.options('*', (c) => {
     const origin = c.req.header('origin');
     const headers = new Headers({ Vary: 'Origin' });
-    if (isDevMode || origin === ALLOWED_ORIGIN) {
-      headers.set('Access-Control-Allow-Origin', isDevMode ? (origin ?? '*') : ALLOWED_ORIGIN);
+    if (isDevMode || isAllowedOrigin(origin)) {
+      headers.set('Access-Control-Allow-Origin', isDevMode ? (origin ?? '*') : (origin as string));
       headers.set('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS');
       headers.set('Access-Control-Allow-Headers', 'Authorization,Content-Type');
       headers.set('Access-Control-Max-Age', '86400');
@@ -49,8 +57,8 @@ export function createApp() {
     if (!isDevMode) {
       c.res.headers.set('Vary', 'Origin');
       const origin = c.req.header('origin');
-      if (origin === ALLOWED_ORIGIN) {
-        c.res.headers.set('Access-Control-Allow-Origin', ALLOWED_ORIGIN);
+      if (isAllowedOrigin(origin)) {
+        c.res.headers.set('Access-Control-Allow-Origin', origin as string);
       }
     }
   });

--- a/server/src/routes/stripe.ts
+++ b/server/src/routes/stripe.ts
@@ -12,7 +12,7 @@
  *
  * Configuration (all server-side, never VITE_-prefixed):
  *   STRIPE_SECRET_KEY, STRIPE_WEBHOOK_SECRET, STRIPE_PRICE_ID
- *   APP_BASE_URL (redirect target; falls back to CORS_ORIGIN)
+ *   APP_BASE_URL (redirect target; falls back to the first origin in CORS_ORIGIN)
  *   STRIPE_AUTOMATIC_TAX ('true' to add GST via Stripe Tax — requires Tax to be
  *     activated in the Stripe dashboard first, or Checkout will error)
  */
@@ -30,7 +30,12 @@ const MEMBERSHIPS_TABLE = isDevMode ? 'dev-memberships' : 'memberships';
 const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY || '';
 const STRIPE_WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET || '';
 const STRIPE_PRICE_ID = process.env.STRIPE_PRICE_ID || '';
-const APP_BASE_URL = (process.env.APP_BASE_URL || process.env.CORS_ORIGIN || 'https://firesantarun.com.au').replace(/\/$/, '');
+// CORS_ORIGIN may be a comma-separated allowlist (see app.ts) — only its
+// first entry is a valid redirect target, so take that when APP_BASE_URL
+// isn't set explicitly.
+const APP_BASE_URL = (
+  process.env.APP_BASE_URL || process.env.CORS_ORIGIN?.split(',')[0]?.trim() || 'https://firesantarun.com.au'
+).replace(/\/$/, '');
 // GST via Stripe Tax is opt-in: enabling automatic_tax when Tax isn't activated
 // in the dashboard makes Checkout fail, so gate it behind an explicit flag.
 const STRIPE_AUTOMATIC_TAX = process.env.STRIPE_AUTOMATIC_TAX === 'true';

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 :root {
   /* ===== FIRE SANTA RUN DESIGN SYSTEM v2.0 ===== */
-  /* Station Manager / Bushie Tools family — signal red, cool slate neutrals,
+  /* Station Manager / StationKit family — signal red, cool slate neutrals,
    * Baloo 2 + Public Sans + JetBrains Mono. See handoff/IMPLEMENTATION.md. */
 
   /* ---- Brand ---- */


### PR DESCRIPTION
## Summary
Station Manager's public branding/URL moved to `stationkit.com.au`. This app is moving from its independent `firesantarun.com.au` domain to `santa.stationkit.com.au` to match — this PR prepares the server side for that cutover without breaking the currently-live domain.

- `server/src/app.ts`: `CORS_ORIGIN` now accepts a comma-separated allowlist (was a single exact-match origin) and defaults, in prod, to both `https://firesantarun.com.au` and `https://santa.stationkit.com.au` during the transition.
- `infra/seed-secrets.sh`: seeds the same two-origin `CORS_ORIGIN` default for prod deploys; `APP_BASE_URL` (used for generated links — SMS broadcasts, Stripe checkout redirects) deliberately still defaults to `firesantarun.com.au` only, since flipping it before DNS exists would 404 real links.
- `server/src/routes/stripe.ts`: fixed a latent issue this change would otherwise introduce — its `APP_BASE_URL` fallback previously read the raw `CORS_ORIGIN` value directly, which would now be a comma-separated list and produce a broken redirect URL. It now takes only the first entry.
- `infra/.env.example`, `infra/README.md`: docs updated for the split `APP_BASE_URL`/`CORS_ORIGIN` behavior.
- `src/index.css`: "Bushie Tools" → "StationKit" in a design-lineage comment.
- `MASTER_PLAN.md`: new operational-readiness entry tracking the domain move.

No Station Manager SSO/auth integration exists in this repo today — this is domain/CORS alignment only, no functional coupling to change.

## Still open (infra/ops, not code)
- Cloudflare DNS + TLS for `santa.stationkit.com.au` and its Container Apps custom-domain binding.
- Once live: flip `APP_BASE_URL` to the new domain and narrow `CORS_ORIGIN` back to the single new origin, retiring `firesantarun.com.au`.

## Test plan
- [x] Manually reviewed the CORS logic change (preflight + response-header paths) for correctness against the existing single-origin behavior
- [ ] `npx tsc -b`, `npm run lint`, `npx vitest run` (not run in this sandbox — no `node_modules`/network available; changes are additive to existing origin-check logic, no other logic touched)

Companion changes: Station-Manager PR (suite app launcher links), Fire Break Calculator PR (SUITE_AUTH_URL + branding), same branch name across all three repos.


---
_Generated by [Claude Code](https://claude.ai/code/session_014z9xwP5kixcepcKi3RXaWc)_